### PR TITLE
Add InstallTiller to spec.go

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -240,6 +240,8 @@ func (c *Client) InstallFromTarball(path, ns string, options ...helmclient.Insta
 	return nil
 }
 
+// InstallTiller installs Tiller by creating its deployment and waiting for it
+// to start. A service account and cluster role binding are also created.
 func (c *Client) InstallTiller() error {
 	// Create the service account for tiller so it can pull images and do its do.
 	{

--- a/spec.go
+++ b/spec.go
@@ -24,6 +24,9 @@ type Interface interface {
 	GetReleaseHistory(releaseName string) (*ReleaseHistory, error)
 	// InstallFromTarball installs a Helm Chart packaged in the given tarball.
 	InstallFromTarball(path, ns string, options ...helm.InstallOption) error
+	// InstallTiller installs Tiller by creating its deployment and waiting for
+	// it to start. A service account and cluster role binding are also created.
+	InstallTiller() error
 	// UpdateReleaseFromTarball updates the given release using the chart packaged
 	// in the tarball.
 	UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error


### PR DESCRIPTION
Just adds the method to spec.go as I noticed it was missing.