### PR TITLE
Rename tillerPodName to avoid clashes and add logging info

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -138,6 +138,7 @@ func (c *Client) EnsureTillerInstalled() error {
 
 		_, err := c.k8sClient.CoreV1().ServiceAccounts(n).Create(i)
 		if errors.IsAlreadyExists(err) {
+			c.logger.Log("level", "debug", "message", fmt.Sprintf("serviceaccount %s creation failed", tillerPodName), "stack", fmt.Sprintf("%#v", err))
 			// fall through
 		} else if err != nil {
 			return microerror.Mask(err)
@@ -170,6 +171,7 @@ func (c *Client) EnsureTillerInstalled() error {
 
 		_, err := c.k8sClient.RbacV1().ClusterRoleBindings().Create(i)
 		if errors.IsAlreadyExists(err) {
+			c.logger.Log("level", "debug", "message", fmt.Sprintf("clusterrolebinding %s creation failed", tillerPodName), "stack", fmt.Sprintf("%#v", err))
 			// fall through
 		} else if err != nil {
 			return microerror.Mask(err)
@@ -186,6 +188,7 @@ func (c *Client) EnsureTillerInstalled() error {
 
 		err := installer.Install(c.k8sClient, o)
 		if errors.IsAlreadyExists(err) {
+			c.logger.Log("level", "debug", "message", "tiller deployment installation failed", "stack", fmt.Sprintf("%#v", err))
 			// fall through
 		} else if err != nil {
 			return microerror.Mask(err)

--- a/spec.go
+++ b/spec.go
@@ -6,7 +6,7 @@ const (
 	tillerDefaultNamespace = "kube-system"
 	tillerImageSpec        = "gcr.io/kubernetes-helm/tiller:v2.8.2"
 	tillerLabelSelector    = "app=helm,name=tiller"
-	tillerPodName          = "tiller"
+	tillerPodName          = "tiller-giantswarm"
 	tillerPort             = 44134
 )
 


### PR DESCRIPTION
If we try to deploy tiller on a different namespace the ServiceAccount and ClusterRolebinding might be already there for another tiller deployment, these changes prevent clashes and add logging info.