### PR TITLE
add additional info for invalid gzip header

### DIFF
--- a/error.go
+++ b/error.go
@@ -44,6 +44,30 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+const (
+	invalidGZipHeaderErrorPrefix = "gzip: invalid header"
+)
+
+var invalidGZipHeaderError = microerror.New("invalid gzip header")
+
+// IsInvalidGZipHeader asserts invalidGZipHeaderError.
+func IsInvalidGZipHeader(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasPrefix(c.Error(), invalidGZipHeaderErrorPrefix) {
+		return true
+	}
+	if c == invalidGZipHeaderError {
+		return true
+	}
+
+	return false
+}
+
 var podNotFoundError = microerror.New("pod not found")
 
 // IsPodNotFound asserts podNotFoundError.


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/3109

This will give us more insight into the laconic `gzip: invalid header` error.