### PR TITLE
Show returned file contents on invalid gzip header failure

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -2,6 +2,7 @@ package helmclient
 
 import (
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -365,7 +366,12 @@ func (c *Client) InstallFromTarball(path, ns string, options ...helmclient.Insta
 			return backoff.Permanent(cannotReuseReleaseError)
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {
-				c.logger.Log("level", "debug", "message", fmt.Sprintf("invalid GZip header, returned release info: %#v", release), "stack", fmt.Sprintf("%#v", err))
+				content, readErr := ioutil.ReadFile(path)
+				if readErr == nil {
+					c.logger.Log("level", "debug", "message", fmt.Sprintf("invalid GZip header, returned release info: %#v, tarball file content %s", release, content), "stack", fmt.Sprintf("%#v", err))
+				} else {
+					c.logger.Log("level", "debug", "message", fmt.Sprintf("could not read chart tarball %s", path), "stack", fmt.Sprintf("%#v", readErr))
+				}
 			}
 			return microerror.Mask(err)
 		}
@@ -400,7 +406,12 @@ func (c *Client) UpdateReleaseFromTarball(releaseName, path string, options ...h
 			return backoff.Permanent(microerror.Maskf(releaseNotFoundError, releaseName))
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {
-				c.logger.Log("level", "debug", "message", fmt.Sprintf("invalid GZip header, returned release info: %#v", release), "stack", fmt.Sprintf("%#v", err))
+				content, readErr := ioutil.ReadFile(path)
+				if readErr == nil {
+					c.logger.Log("level", "debug", "message", fmt.Sprintf("invalid GZip header, returned release info: %#v, tarball file content %s", release, content), "stack", fmt.Sprintf("%#v", err))
+				} else {
+					c.logger.Log("level", "debug", "message", fmt.Sprintf("could not read chart tarball %s", path), "stack", fmt.Sprintf("%#v", readErr))
+				}
 			}
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3109

When we get an invalid gzip header failure it is usually because we are trying to install a chart from a tarball file and, because of an error condition, the file contains json error response instead of a gzipped chart. With these changes we will get the content of that json document in the error log in case of an invalid gzip header failure.