### PR TITLE
Return annotated tiller installation error

### DIFF
--- a/error.go
+++ b/error.go
@@ -103,6 +103,13 @@ func IsReleaseNotFound(err error) bool {
 	return false
 }
 
+var tillerInstallationFailedError = microerror.New("Tiller installation failed")
+
+// IsTillerInstallationFailed asserts tillerInstallationFailedError.
+func IsTillerInstallationFailed(err error) bool {
+	return microerror.Cause(err) == tillerInstallationFailedError
+}
+
 var tooManyResultsError = microerror.New("too many results")
 
 // IsTooManyResults asserts tooManyResultsError.

--- a/helmclient.go
+++ b/helmclient.go
@@ -230,7 +230,7 @@ func (c *Client) EnsureTillerInstalled() error {
 
 		err := backoff.RetryNotify(o, b, n)
 		if err != nil {
-			return microerror.Mask(err)
+			return microerror.Maskf(tillerInstallationFailedError, err.Error())
 		}
 
 		c.logger.Log("level", "debug", "message", "succeeded pinging tiller")


### PR DESCRIPTION
Towards https://github.com/giantswarm/cluster-operator/issues/103

This will allow us to check a Tiller installation error and stop reconciliation in that case instead of bailing out.