### PR TITLE
Add function for asserting guest API not available errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,6 +38,7 @@ func IsExecutionFailed(err error) bool {
 	return microerror.Cause(err) == executionFailedError
 }
 
+var guestAPINotAvailableError = microerror.New("Guest API not available")
 var guestNamespaceCreationErrorSuffix = "namespaces/kube-system/serviceaccounts: EOF"
 
 // match example https://play.golang.org/p/ipBkwqlc4Td
@@ -59,6 +60,10 @@ func IsGuestAPINotAvailable(err error) bool {
 		return false
 	}
 	if matched {
+		return true
+	}
+
+	if c == guestAPINotAvailableError {
 		return true
 	}
 

--- a/error.go
+++ b/error.go
@@ -37,6 +37,25 @@ func IsExecutionFailed(err error) bool {
 	return microerror.Cause(err) == executionFailedError
 }
 
+var guestNamespaceCreationErrorSuffix = "namespaces/kube-system/serviceaccounts: EOF"
+var guestDNSNotReadySuffix = "53: no such host"
+
+// IsGuestAPINotAvailable asserts guestAPINotAvailableError.
+func IsGuestAPINotAvailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if strings.HasSuffix(err.Error(), guestNamespaceCreationErrorSuffix) {
+		return true
+	}
+	if strings.HasSuffix(err.Error(), guestDNSNotReadySuffix) {
+		return true
+	}
+
+	return false
+}
+
 var invalidConfigError = microerror.New("invalid config")
 
 // IsInvalidConfig asserts invalidConfigError.

--- a/helmclient.go
+++ b/helmclient.go
@@ -141,6 +141,8 @@ func (c *Client) EnsureTillerInstalled() error {
 		if errors.IsAlreadyExists(err) {
 			c.logger.Log("level", "debug", "message", fmt.Sprintf("serviceaccount %s creation failed", tillerPodName), "stack", fmt.Sprintf("%#v", err))
 			// fall through
+		} else if IsGuestAPINotAvailable(err) {
+			return microerror.Maskf(guestAPINotAvailableError, err.Error())
 		} else if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
This will allow us to detect errors related to the guest API not being available and act according to that in consumer code, for instance, we may stop a reconciliation loop if we are getting this kind of error after creating a guest cluster and expect to have the API ready soon.