### PR TITLE
Expose PingTiller

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -400,6 +400,22 @@ func (c *Client) InstallFromTarball(path, ns string, options ...helmclient.Insta
 	return nil
 }
 
+// PingTiller proxies the underlying Helm client PingTiller method.
+func (c *Client) PingTiller() error {
+	t, err := c.newTunnel()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer c.closeTunnel(t)
+
+	err = c.newHelmClientFromTunnel(t).PingTiller()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
 // RunReleaseTest runs the tests for a Helm Release. The releaseName is the
 // name of the Helm Release that is set when the Helm Chart is installed. This
 // is the same action as running the helm test command.

--- a/spec.go
+++ b/spec.go
@@ -29,6 +29,8 @@ type Interface interface {
 	GetReleaseHistory(releaseName string) (*ReleaseHistory, error)
 	// InstallFromTarball installs a Helm Chart packaged in the given tarball.
 	InstallFromTarball(path, ns string, options ...helm.InstallOption) error
+	// PingTiller proxies the underlying Helm client PingTiller method.
+	PingTiller() error
 	// RunReleaseTest runs the tests for a Helm Release. This is the same
 	// action as running the helm test command.
 	RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3925

Makes available PingTiller to external consumers of the library, this will be useful to create an alert on Tiller unreachable.