### PR TITLE
Set helm init's max history param

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -192,6 +192,7 @@ func (c *Client) EnsureTillerInstalled() error {
 	{
 		o := &installer.Options{
 			ImageSpec:      tillerImageSpec,
+			MaxHistory:     defaultMaxHistory,
 			Namespace:      c.tillerNamespace,
 			ServiceAccount: tillerPodName,
 		}

--- a/spec.go
+++ b/spec.go
@@ -3,6 +3,10 @@ package helmclient
 import "k8s.io/helm/pkg/helm"
 
 const (
+	// defaultMaxHistory is the maximum number of release versions stored per
+	// release by default.
+	defaultMaxHistory = 10
+
 	tillerDefaultNamespace = "kube-system"
 	tillerImageSpec        = "quay.io/giantswarm/tiller:v2.8.2"
 	tillerLabelSelector    = "app=helm,name=tiller"


### PR DESCRIPTION
Aims to prevent an unlimited number of previous release versions to be stored. See https://gigantic.slack.com/archives/C02MS174K/p1535545641000100