### PR TITLE
return tillerNotFound error

### DIFF
--- a/error.go
+++ b/error.go
@@ -76,13 +76,13 @@ func IsInvalidGZipHeader(err error) bool {
 	return false
 }
 
-var podNotFoundError = &microerror.Error{
-	Kind: "podNotFoundError",
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
 }
 
-// IsPodNotFound asserts podNotFoundError.
-func IsPodNotFound(err error) bool {
-	return microerror.Cause(err) == podNotFoundError
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
 }
 
 const (
@@ -140,6 +140,15 @@ var tillerInstallationFailedError = &microerror.Error{
 // IsTillerInstallationFailed asserts tillerInstallationFailedError.
 func IsTillerInstallationFailed(err error) bool {
 	return microerror.Cause(err) == tillerInstallationFailedError
+}
+
+var tillerNotFoundError = &microerror.Error{
+	Kind: "tillerNotFoundError",
+}
+
+// IsTillerNotFound asserts tillerNotFoundError.
+func IsTillerNotFound(err error) bool {
+	return microerror.Cause(err) == tillerNotFoundError
 }
 
 var tooManyResultsError = &microerror.Error{

--- a/helmclient.go
+++ b/helmclient.go
@@ -543,7 +543,9 @@ func (c *Client) newTunnel() (*k8sportforward.Tunnel, error) {
 	}
 
 	podName, err := getPodName(c.k8sClient, tillerLabelSelector, c.tillerNamespace)
-	if err != nil {
+	if IsNotFound(err) {
+		return nil, microerror.Maskf(tillerNotFoundError, "label selector: %#q namespace: %#q", tillerLabelSelector, c.tillerNamespace)
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
@@ -583,7 +585,7 @@ func getPodName(client kubernetes.Interface, labelSelector, namespace string) (s
 		return "", microerror.Maskf(tooManyResultsError, "%d", len(pods.Items))
 	}
 	if len(pods.Items) == 0 {
-		return "", microerror.Maskf(podNotFoundError, "%s", labelSelector)
+		return "", microerror.Maskf(notFoundError, "%s", labelSelector)
 	}
 	pod := pods.Items[0]
 


### PR DESCRIPTION
... instead of meaningless pod not found.

Towards https://github.com/giantswarm/giantswarm/issues/4059.

Again this allows to build idempotent code around that function call.