### PR TITLE
Add helmclienttest package

### DIFF
--- a/helmclienttest/helmclient.go
+++ b/helmclienttest/helmclient.go
@@ -1,0 +1,78 @@
+package helmclienttest
+
+import (
+	"context"
+
+	"github.com/giantswarm/helmclient"
+	"k8s.io/helm/pkg/helm"
+)
+
+type Config struct {
+	DefaultReleaseContent *helmclient.ReleaseContent
+	DefaultReleaseHistory *helmclient.ReleaseHistory
+	DefaultError          error
+}
+
+type Client struct {
+	defaultReleaseContent *helmclient.ReleaseContent
+	defaultReleaseHistory *helmclient.ReleaseHistory
+	defaultError          error
+}
+
+func New(config Config) (helmclient.Interface, error) {
+	c := &Client{
+		defaultReleaseContent: config.DefaultReleaseContent,
+		defaultReleaseHistory: config.DefaultReleaseHistory,
+		defaultError:          config.DefaultError,
+	}
+
+	return c, nil
+}
+
+func (c *Client) DeleteRelease(ctx context.Context, releaseName string, options ...helm.DeleteOption) error {
+	if c.defaultError != nil {
+		return c.defaultError
+	}
+
+	return nil
+}
+
+func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
+	return nil
+}
+
+func (c *Client) GetReleaseContent(ctx context.Context, releaseName string) (*helmclient.ReleaseContent, error) {
+	if c.defaultError != nil {
+		return nil, c.defaultError
+	}
+
+	return c.defaultReleaseContent, nil
+}
+
+func (c *Client) GetReleaseHistory(ctx context.Context, releaseName string) (*helmclient.ReleaseHistory, error) {
+	if c.defaultError != nil {
+		return nil, c.defaultError
+	}
+
+	return c.defaultReleaseHistory, nil
+}
+
+func (c *Client) InstallReleaseFromTarball(ctx context.Context, path, ns string, options ...helm.InstallOption) error {
+	return nil
+}
+
+func (c *Client) ListReleaseContents(ctx context.Context) ([]*helmclient.ReleaseContent, error) {
+	return nil, nil
+}
+
+func (c *Client) RunReleaseTest(ctx context.Context, releaseName string, options ...helm.ReleaseTestOption) error {
+	return nil
+}
+
+func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path string, options ...helm.UpdateOption) error {
+	return nil
+}
+
+func (c *Client) PingTiller(ctx context.Context) error {
+	return nil
+}

--- a/helmclienttest/helmclient.go
+++ b/helmclienttest/helmclient.go
@@ -65,14 +65,14 @@ func (c *Client) ListReleaseContents(ctx context.Context) ([]*helmclient.Release
 	return nil, nil
 }
 
+func (c *Client) PingTiller(ctx context.Context) error {
+	return nil
+}
+
 func (c *Client) RunReleaseTest(ctx context.Context, releaseName string, options ...helm.ReleaseTestOption) error {
 	return nil
 }
 
 func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path string, options ...helm.UpdateOption) error {
-	return nil
-}
-
-func (c *Client) PingTiller(ctx context.Context) error {
 	return nil
 }

--- a/helmclienttest/helmclient_test.go
+++ b/helmclienttest/helmclient_test.go
@@ -1,0 +1,15 @@
+package helmclienttest
+
+import (
+	"testing"
+)
+
+func Test_New(t *testing.T) {
+	c := Config{}
+
+	// Test that New doesn't panic and helmclient.Interface is implemented.
+	_, err := New(c)
+	if err != nil {
+		t.Fatalf("error == %#v, want nil", err)
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4949

This is prep for some helmclient changes I need to make for chart-operator. Adds the helmclienttest package so we can remove the `mock_test.go` files we have in chart-operator and cluster-operator.

e.g. https://github.com/giantswarm/chart-operator/blob/1553942b22cbecea7b26b7b90bb56399d3b3d8f6/service/controller/chartconfig/v5/resource/chart/mock_test.go
