### PR TITLE
Don't return error in helmclienttest constructor

### DIFF
--- a/helmclienttest/helmclient.go
+++ b/helmclienttest/helmclient.go
@@ -28,7 +28,7 @@ type Client struct {
 	pullChartTarballPath  string
 }
 
-func New(config Config) (helmclient.Interface, error) {
+func New(config Config) helmclient.Interface {
 	c := &Client{
 		defaultError:          config.DefaultError,
 		defaultReleaseContent: config.DefaultReleaseContent,
@@ -39,7 +39,7 @@ func New(config Config) (helmclient.Interface, error) {
 		pullChartTarballPath:  config.PullChartTarballPath,
 	}
 
-	return c, nil
+	return c
 }
 
 func (c *Client) DeleteRelease(ctx context.Context, releaseName string, options ...helm.DeleteOption) error {

--- a/helmclienttest/helmclient_test.go
+++ b/helmclienttest/helmclient_test.go
@@ -5,11 +5,6 @@ import (
 )
 
 func Test_New(t *testing.T) {
-	c := Config{}
-
 	// Test that New doesn't panic and helmclient.Interface is implemented.
-	_, err := New(c)
-	if err != nil {
-		t.Fatalf("error == %#v, want nil", err)
-	}
+	New(Config{})
 }


### PR DESCRIPTION
Same issue as with `apprclienttest`. See https://github.com/giantswarm/apprclient/pull/25.