### PR TITLE
Improve tiller version check when deployment has been changed manually

### DIFF
--- a/helmclient_test.go
+++ b/helmclient_test.go
@@ -604,7 +604,7 @@ func Test_isTillerOutdated(t *testing.T) {
 			errorMatcher: IsTillerOutdated,
 		},
 		{
-			name: "case 4: tiller image has no version tag",
+			name: "case 4: tiller image has no version tag so we upgrade",
 			tillerPod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -614,10 +614,23 @@ func Test_isTillerOutdated(t *testing.T) {
 					},
 				},
 			},
-			errorMatcher: IsExecutionFailed,
+			errorMatcher: IsTillerOutdated,
 		},
 		{
-			name: "case 5: tiller image tag format is invalid",
+			name: "case 5: tiller image uses latest tag so we upgrade",
+			tillerPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "quay.io/giantswarm/tiller:latest",
+						},
+					},
+				},
+			},
+			errorMatcher: IsTillerOutdated,
+		},
+		{
+			name: "case 6: tiller image tag format is invalid",
 			tillerPod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -630,7 +643,7 @@ func Test_isTillerOutdated(t *testing.T) {
 			errorMatcher: IsExecutionFailed,
 		},
 		{
-			name: "case 6: tiller image tag format is invalid",
+			name: "case 7: tiller image tag format is invalid",
 			tillerPod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
We had a problem in `talos` because the Tiller deployment had been changed manually and didn't have a version tag `quay.io/giantswarm/tiller`. 

```
panic: [{/go/src/github.com/giantswarm/draughtsman/service/service.go:171: service.Boot} {/go/src/github.com/giantswarm/draughtsman/vendor/github.com/giantswarm/helmclient/helmclient.go:278: } {/go/src/github.com/giantswarm/draughtsman/vendor/github.com/giantswarm/helmclient/helmclient.go:863: } {/go/src/github.com/giantswarm/draughtsman/vendor/github.com/giantswarm/helmclient/helmclient.go:886: tiller image `quay.io/giantswarm/tiller` is invalid} {execution failed error}]
```

Currently we error and this causes a panic and alerts. This is to make the version check smarter. If the image tag is empty or `latest` we treat it as outdated. So the tiller deployment gets upgraded to have the correct version.


See https://gigantic.slack.com/archives/C03CPNRTS/p1547479149027500.