### PR TITLE
Wait for tiller to be installed

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -271,7 +271,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 		}
 	}
 
-	if pod != nil {
+	if !installTiller && pod != nil {
 		err = validateTillerVersion(pod, c.tillerImage)
 		if IsTillerOutdated(err) {
 			upgradeTiller = true

--- a/helmclient.go
+++ b/helmclient.go
@@ -262,7 +262,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 
 			return nil
 		}
-		b := backoff.NewExponential(2*time.Minute, 5*time.Second)
+		b := backoff.NewExponential(1*time.Minute, 5*time.Second)
 		n := backoff.NewNotifier(c.logger, context.Background())
 
 		err := backoff.RetryNotify(o, b, n)
@@ -333,7 +333,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 
 			return nil
 		}
-		b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+		b := backoff.NewExponential(1*time.Minute, 5*time.Second)
 		n := backoff.NewNotifier(c.logger, ctx)
 
 		err := backoff.RetryNotify(o, b, n)

--- a/helmclient.go
+++ b/helmclient.go
@@ -303,18 +303,17 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 		return microerror.Maskf(executionFailedError, "invalid state cannot both install and upgrade tiller")
 	}
 
-	// Wait for tiller to be up and running. We wait 3 attempts before giving
-	// up. When verifying to be able to ping tiller we make sure 3 consecutive
-	// pings succeed before assuming everything is fine.
+	// Wait for tiller to be up and running. When verifying to be able to ping
+	// tiller we make sure 3 consecutive pings succeed before assuming everything
+	// is fine.
 	{
 		c.logger.LogCtx(ctx, "level", "debug", "message", "waiting for tiller to be up")
 
-		var newTunnelCount, pingTillerCount int
+		var i int
 
 		o := func() error {
 			t, err := c.newTunnel()
 			if IsTillerNotFound(err) && newTunnelCount < 3 {
-				// Stop as tiller still not found.
 				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
@@ -323,14 +322,12 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 
 			err = c.newHelmClientFromTunnel(t).PingTiller()
 			if err != nil {
-				// Ping attempt failed so reset counter.
-				pingTillerCount = 0
+				i = 0
 				return microerror.Mask(err)
 			}
 
-			newTunnelCount++
-			pingTillerCount++
-			if pingTillerCount < 3 {
+			i++
+			if i < 3 {
 				return microerror.Maskf(executionFailedError, "failed to ping tiller 3 consecutive times")
 			}
 

--- a/helmclient.go
+++ b/helmclient.go
@@ -303,17 +303,18 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 		return microerror.Maskf(executionFailedError, "invalid state cannot both install and upgrade tiller")
 	}
 
-	// Wait for tiller to be up and running. When verifying to be able to ping
-	// tiller we make sure 3 consecutive pings succeed before assuming everything
-	// is fine.
+	// Wait for tiller to be up and running. We wait 3 attempts before giving
+	// up. When verifying to be able to ping tiller we make sure 3 consecutive
+	// pings succeed before assuming everything is fine.
 	{
 		c.logger.LogCtx(ctx, "level", "debug", "message", "waiting for tiller to be up")
 
-		var i int
+		var newTunnelCount, pingTillerCount int
 
 		o := func() error {
 			t, err := c.newTunnel()
-			if IsTillerNotFound(err) {
+			if IsTillerNotFound(err) && newTunnelCount < 3 {
+				// Stop as tiller still not found.
 				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
@@ -322,12 +323,14 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 
 			err = c.newHelmClientFromTunnel(t).PingTiller()
 			if err != nil {
-				i = 0
+				// Ping attempt failed so reset counter.
+				pingTillerCount = 0
 				return microerror.Mask(err)
 			}
 
-			i++
-			if i < 3 {
+			newTunnelCount++
+			pingTillerCount++
+			if pingTillerCount < 3 {
 				return microerror.Maskf(executionFailedError, "failed to ping tiller 3 consecutive times")
 			}
 

--- a/helmclient.go
+++ b/helmclient.go
@@ -313,7 +313,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 
 		o := func() error {
 			t, err := c.newTunnel()
-			if IsTillerNotFound(err) && newTunnelCount < 3 {
+			if !installTiller && IsTillerNotFound(err) {
 				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5218

Fixes to helmclient needed for https://github.com/giantswarm/cluster-operator/pull/386. With this all chartconfig CRs and chart-operator are installed in a single reconciliation loop the first time the tenant cluster becomes available.