### PR TITLE
Fix check when both install and upgrade tiller are true

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -299,7 +299,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-	} else {
+	} else if installTiller && upgradeTiller {
 		return microerror.Maskf(executionFailedError, "invalid state cannot both install and upgrade tiller")
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5224

I've seen this error `invalid state cannot both install and upgrade tiller` a few times during cluster creation when cluster-operator is bootstrapping tiller.

This fixes the current check which is just wrong. 🤦‍♂️ 