### PR TITLE
Add priorityclass to ensure it exists when installing tiller

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -258,6 +258,8 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 	{
 		priorityClassName := "giantswarm-critical"
 
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating priorityclass %#q", priorityClassName))
+
 		p := &schedulingv1beta1.PriorityClass{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "scheduling.k8s.io/v1alpha1",
@@ -271,7 +273,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			Description:   "This priority class is used by giantswarm kubernetes components.",
 		}
 
-		_, err := c.k8sClient.SchedulingV1alpha1().PriorityClasses().Create(p)
+		_, err := c.k8sClient.SchedulingV1beta1().PriorityClasses().Create(p)
 		if errors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("priorityclass %#q already exists", priorityClassName))
 			// fall through

--- a/helmclient.go
+++ b/helmclient.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	schedulingv1alpha1 "k8s.io/api/scheduling/v1alpha1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -255,11 +255,10 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 	}
 
 	// Create the priority class for tiller to make sure it is always deployed.
-
 	{
 		priorityClassName := "giantswarm-critical"
 
-		p := &schedulingv1alpha1.PriorityClass{
+		p := &schedulingv1beta1.PriorityClass{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "scheduling.k8s.io/v1alpha1",
 				Kind:       "PriorityClass",


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/chart-operator/pull/206

Priority class is the same as https://github.com/giantswarm/k8scloudconfig/blob/100d834280834beb78233661a6a6d7aeecba7749/v_4_1_1/files/k8s-resource/priority_classes.yaml