### PR TITLE
Reduce backoff exponential time & catch YAML parsing error as permanent

### DIFF
--- a/error.go
+++ b/error.go
@@ -221,3 +221,29 @@ var tooManyResultsError = &microerror.Error{
 func IsTooManyResults(err error) bool {
 	return microerror.Cause(err) == tooManyResultsError
 }
+
+var (
+	yamlConvertingFailedRegexp = regexp.MustCompile(`error converting YAML to JSON:`)
+)
+
+var yamlConvertingFailedError = &microerror.Error{
+	Kind: "releaseAlreadyExistsError",
+}
+
+// IsYamlConvertingFailed asserts yamlConvertingFailedError.
+func IsYamlConvertingFailed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == yamlConvertingFailedError {
+		return true
+	}
+	if yamlConvertingFailedRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}

--- a/error.go
+++ b/error.go
@@ -223,7 +223,7 @@ func IsTooManyResults(err error) bool {
 }
 
 var (
-	yamlConvertingFailedPrefix = "error converting YAML to JSON:"
+	yamlConversionFailedErrorText = "error converting YAML to JSON:"
 )
 
 var yamlConvertingFailedError = &microerror.Error{
@@ -241,7 +241,7 @@ func IsYamlConvertingFailed(err error) bool {
 	if c == yamlConvertingFailedError {
 		return true
 	}
-	if strings.Contains(c.Error(), yamlConvertingFailedPrefix) {
+	if strings.Contains(c.Error(), yamlConversionFailedErrorText) {
 		return true
 	}
 

--- a/error.go
+++ b/error.go
@@ -223,11 +223,11 @@ func IsTooManyResults(err error) bool {
 }
 
 var (
-	yamlConvertingFailedRegexp = regexp.MustCompile(`error converting YAML to JSON:`)
+	yamlConvertingFailedPrefix = "error converting YAML to JSON:"
 )
 
 var yamlConvertingFailedError = &microerror.Error{
-	Kind: "releaseAlreadyExistsError",
+	Kind: "yamlConvertingFailedError",
 }
 
 // IsYamlConvertingFailed asserts yamlConvertingFailedError.
@@ -241,7 +241,7 @@ func IsYamlConvertingFailed(err error) bool {
 	if c == yamlConvertingFailedError {
 		return true
 	}
-	if yamlConvertingFailedRegexp.MatchString(c.Error()) {
+	if strings.Contains(c.Error(), yamlConvertingFailedPrefix) {
 		return true
 	}
 

--- a/error.go
+++ b/error.go
@@ -226,19 +226,19 @@ var (
 	yamlConversionFailedErrorText = "error converting YAML to JSON:"
 )
 
-var yamlConvertingFailedError = &microerror.Error{
+var yamlConversionFailedError = &microerror.Error{
 	Kind: "yamlConvertingFailedError",
 }
 
 // IsYamlConvertingFailed asserts yamlConvertingFailedError.
-func IsYamlConvertingFailed(err error) bool {
+func IsYamlConversionFailed(err error) bool {
 	if err == nil {
 		return false
 	}
 
 	c := microerror.Cause(err)
 
-	if c == yamlConvertingFailedError {
+	if c == yamlConversionFailedError {
 		return true
 	}
 	if strings.Contains(c.Error(), yamlConversionFailedErrorText) {

--- a/error.go
+++ b/error.go
@@ -227,10 +227,10 @@ var (
 )
 
 var yamlConversionFailedError = &microerror.Error{
-	Kind: "yamlConvertingFailedError",
+	Kind: "yamlConversionFailedError",
 }
 
-// IsYamlConversionFailed asserts yamlConvertingFailedError.
+// IsYamlConversionFailed asserts yamlConversionFailedError.
 func IsYamlConversionFailed(err error) bool {
 	if err == nil {
 		return false

--- a/error.go
+++ b/error.go
@@ -230,7 +230,7 @@ var yamlConversionFailedError = &microerror.Error{
 	Kind: "yamlConvertingFailedError",
 }
 
-// IsYamlConvertingFailed asserts yamlConvertingFailedError.
+// IsYamlConversionFailed asserts yamlConvertingFailedError.
 func IsYamlConversionFailed(err error) bool {
 	if err == nil {
 		return false

--- a/helmclient.go
+++ b/helmclient.go
@@ -496,6 +496,7 @@ func (c *Client) InstallReleaseFromTarball(ctx context.Context, path, ns string,
 					c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("could not read chart tarball %s", path), "stack", fmt.Sprintf("%#v", readErr))
 				}
 			}
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("err string: %#q", err.Error()))
 			return microerror.Mask(err)
 		}
 
@@ -670,6 +671,7 @@ func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path
 					c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("could not read chart tarball %s", path), "stack", fmt.Sprintf("%#v", readErr))
 				}
 			}
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("err string: %#q", err.Error()))
 			return microerror.Mask(err)
 		}
 

--- a/helmclient.go
+++ b/helmclient.go
@@ -487,6 +487,8 @@ func (c *Client) InstallReleaseFromTarball(ctx context.Context, path, ns string,
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsTarballNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
+		} else if IsYamlConvertingFailed(err) {
+			return backoff.Permanent(microerror.Mask(err))
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {
 				content, readErr := ioutil.ReadFile(path)
@@ -661,6 +663,8 @@ func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path
 
 		release, err := c.newHelmClientFromTunnel(t).UpdateRelease(releaseName, path, options...)
 		if IsReleaseNotFound(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsYamlConvertingFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {

--- a/helmclient.go
+++ b/helmclient.go
@@ -487,7 +487,7 @@ func (c *Client) InstallReleaseFromTarball(ctx context.Context, path, ns string,
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsTarballNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
-		} else if IsYamlConvertingFailed(err) {
+		} else if IsYamlConversionFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {
@@ -664,7 +664,7 @@ func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path
 		release, err := c.newHelmClientFromTunnel(t).UpdateRelease(releaseName, path, options...)
 		if IsReleaseNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
-		} else if IsYamlConvertingFailed(err) {
+		} else if IsYamlConversionFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {

--- a/helmclient.go
+++ b/helmclient.go
@@ -674,7 +674,7 @@ func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path
 
 		return nil
 	}
-	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	b := backoff.NewExponential(30*time.Second, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)

--- a/helmclient.go
+++ b/helmclient.go
@@ -383,7 +383,7 @@ func (c *Client) GetReleaseContent(ctx context.Context, releaseName string) (*Re
 
 			return nil
 		}
-		b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+		b := backoff.NewExponential(30*time.Second, 5*time.Second)
 		n := backoff.NewNotifier(c.logger, ctx)
 
 		err := backoff.RetryNotify(o, b, n)
@@ -425,7 +425,8 @@ func (c *Client) GetReleaseHistory(ctx context.Context, releaseName string) (*Re
 
 			return nil
 		}
-		b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+		b := backoff.NewExponential(30*time.Second, 5*time.Second)
+
 		n := backoff.NewNotifier(c.logger, ctx)
 
 		err = backoff.RetryNotify(o, b, n)

--- a/helmclient.go
+++ b/helmclient.go
@@ -137,7 +137,7 @@ func (c *Client) DeleteRelease(ctx context.Context, releaseName string, options 
 
 		return nil
 	}
-	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	b := backoff.NewExponential(30*time.Second, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)

--- a/helmclient.go
+++ b/helmclient.go
@@ -500,7 +500,7 @@ func (c *Client) InstallReleaseFromTarball(ctx context.Context, path, ns string,
 
 		return nil
 	}
-	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	b := backoff.NewExponential(30*time.Second, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)

--- a/helmclient.go
+++ b/helmclient.go
@@ -137,7 +137,7 @@ func (c *Client) DeleteRelease(ctx context.Context, releaseName string, options 
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+	b := backoff.NewMaxRetries(10, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)
@@ -383,7 +383,7 @@ func (c *Client) GetReleaseContent(ctx context.Context, releaseName string) (*Re
 
 			return nil
 		}
-		b := backoff.NewExponential(30*time.Second, 5*time.Second)
+		b := backoff.NewMaxRetries(10, 5*time.Second)
 		n := backoff.NewNotifier(c.logger, ctx)
 
 		err := backoff.RetryNotify(o, b, n)
@@ -425,7 +425,7 @@ func (c *Client) GetReleaseHistory(ctx context.Context, releaseName string) (*Re
 
 			return nil
 		}
-		b := backoff.NewExponential(30*time.Second, 5*time.Second)
+		b := backoff.NewMaxRetries(10, 5*time.Second)
 
 		n := backoff.NewNotifier(c.logger, ctx)
 
@@ -501,7 +501,7 @@ func (c *Client) InstallReleaseFromTarball(ctx context.Context, path, ns string,
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+	b := backoff.NewMaxRetries(10, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)
@@ -675,7 +675,7 @@ func (c *Client) UpdateReleaseFromTarball(ctx context.Context, releaseName, path
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+	b := backoff.NewMaxRetries(10, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -65,7 +66,7 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 		return nil
 	}
 
-	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	b := backoff.NewMaxRetries(10, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, ctx)
 
 	err := backoff.RetryNotify(o, b, n)


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/5743

Only affect `InstallReleaseFromTarball` function. 