### PR TITLE
Support merging and processing null valued keys

### DIFF
--- a/merge_values.go
+++ b/merge_values.go
@@ -135,6 +135,12 @@ func processInterfaceMap(in map[interface{}]interface{}) map[string]interface{} 
 }
 
 func processValue(v interface{}) interface{} {
+	// yaml null-valued key unmarshalls to nil value in Go, so nil is a valid value that has to be handled
+	// See https://helm.sh/docs/chart_template_guide/#deleting-a-default-key.
+	if v == nil {
+		return v
+	}
+
 	switch v := v.(type) {
 	case bool:
 		return v

--- a/merge_values_test.go
+++ b/merge_values_test.go
@@ -56,6 +56,9 @@ nested:
   value: "nested"
 test: test`
 
+const nullValuedNestedKeyYaml = `
+nested: null`
+
 func Test_MergeValues(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -148,6 +151,19 @@ func Test_MergeValues(t *testing.T) {
 				"test": []byte("test: val"),
 			},
 			errorMatcher: IsExecutionFailed,
+		},
+		{
+			name: "case 7: null-valued key in src overrides/removes intersecting tree in dest",
+			destMap: map[string][]byte{
+				"simple": []byte(simpleNestedYaml),
+			},
+			srcMap: map[string][]byte{
+				"override": []byte(nullValuedNestedKeyYaml),
+			},
+			expectedValues: map[string]interface{}{
+				"nested": nil,
+				"test":   "test",
+			},
 		},
 	}
 
@@ -262,6 +278,13 @@ func Test_yamlToStringMap(t *testing.T) {
 			name:         "case 5: integer input returns error",
 			input:        []byte("123"),
 			errorMatcher: IsExecutionFailed,
+		},
+		{
+			name:  "case 6: null value is supported",
+			input: []byte(nullValuedNestedKeyYaml),
+			expectedValues: map[string]interface{}{
+				"nested": nil,
+			},
 		},
 	}
 


### PR DESCRIPTION
Setting leaf or even higher level key to `null` is official way of overriding default key setting with intent to having it deleted (see [docs](https://helm.sh/docs/chart_template_guide/#deleting-a-default-key)). To be able to use `helmclient.MergeValues` in `opsctl ensure appcatalogs` command logic and have the command properly supporting customization / overrides / key deletion via `null` value, merging and processing `null` valued keys needs to be supported. This PR adds that feature.