### PR TITLE
Revert "Tiller upgrade to v2.14.1 (#104)"

### DIFF
--- a/integration/test/upgradetiller/upgrade_tiller_test.go
+++ b/integration/test/upgradetiller/upgrade_tiller_test.go
@@ -18,7 +18,7 @@ func TestUpgradeTiller(t *testing.T) {
 
 	var err error
 
-	currentTillerImage := "quay.io/giantswarm/tiller:v2.14.1"
+	currentTillerImage := "quay.io/giantswarm/tiller:v2.12.0"
 	outdatedTillerImage := "quay.io/giantswarm/tiller:v2.8.2"
 
 	labelSelector := "app=helm,name=tiller"

--- a/spec.go
+++ b/spec.go
@@ -15,7 +15,7 @@ const (
 	// runReleaseTestTimeout is the timeout in seconds when running tests.
 	runReleaseTestTimout = 300
 
-	defaultTillerImage     = "quay.io/giantswarm/tiller:v2.14.1"
+	defaultTillerImage     = "quay.io/giantswarm/tiller:v2.12.0"
 	defaultTillerNamespace = "kube-system"
 	roleBindingNamePrefix  = "tiller"
 	tillerLabelSelector    = "app=helm,name=tiller"


### PR DESCRIPTION
This reverts commit 505b8ddcd168c0e360c766d27849fd7496e83bbb.

To update tiller, we need to update k8s version first. 