### PR TITLE
Add network policy for tiller

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -9,9 +9,11 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/helm/cmd/helm/installer"
 )
 
@@ -117,6 +119,91 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			return microerror.Mask(err)
 		} else {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created clusterrolebinding %#q", name))
+		}
+	}
+
+	// Create the network policy for tiller so it is allowed to do its job in case all traffic is blocked.
+	{
+		networkPolicyName := tillerPodName
+		networkPolicyNamespace := c.tillerNamespace
+		protocolTCP := corev1.ProtocolTCP
+		tillerPort := intstr.IntOrString{
+			IntVal: 44134,
+		}
+		tillerHTTPPort := intstr.IntOrString{
+			IntVal: 44135,
+		}
+
+		name := fmt.Sprintf("%s/%s", networkPolicyNamespace, networkPolicyName)
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating networkpolicy %#q", name))
+
+		np := &networkingv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      networkPolicyName,
+				Namespace: networkPolicyNamespace,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":  "helm",
+						"name": "tiller",
+					},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkingv1.NetworkPolicyIngressRule{
+						Ports: []networkingv1.NetworkPolicyPort{
+							networkingv1.NetworkPolicyPort{
+								Protocol: &protocolTCP,
+								Port:     &tillerPort,
+							},
+							networkingv1.NetworkPolicyPort{
+								Protocol: &protocolTCP,
+								Port:     &tillerHTTPPort,
+							},
+						},
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkingv1.NetworkPolicyEgressRule{
+						To: []networkingv1.NetworkPolicyPeer{
+							networkingv1.NetworkPolicyPeer{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "10.0.0.0/8",
+								},
+							},
+							networkingv1.NetworkPolicyPeer{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "172.16.0.0/12",
+								},
+							},
+							networkingv1.NetworkPolicyPeer{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: "192.168.0.0/16",
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+			},
+		}
+
+		_, err := c.k8sClient.NetworkingV1().NetworkPolicies(networkPolicyNamespace).Create(np)
+		if errors.IsAlreadyExists(err) {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("networkpolicy %#q already exists", name))
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created networkpolicy %#q", name))
 		}
 	}
 

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -169,25 +169,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 					},
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
-					networkingv1.NetworkPolicyEgressRule{
-						To: []networkingv1.NetworkPolicyPeer{
-							networkingv1.NetworkPolicyPeer{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: "10.0.0.0/8",
-								},
-							},
-							networkingv1.NetworkPolicyPeer{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: "172.16.0.0/12",
-								},
-							},
-							networkingv1.NetworkPolicyPeer{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: "192.168.0.0/16",
-								},
-							},
-						},
-					},
+					networkingv1.NetworkPolicyEgressRule{},
 				},
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeIngress,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4033

Code generates policy:

```
apiVersion: extensions/v1beta1
kind: NetworkPolicy
metadata:
  creationTimestamp: "2019-06-19T17:06:25Z"
  generation: 2
  name: tiller-deploy
  namespace: giantswarm
  resourceVersion: "1170583"
  selfLink: /apis/extensions/v1beta1/namespaces/giantswarm/networkpolicies/tiller-deploy
  uid: 9258a16b-92b4-11e9-b419-000d3a44433d
spec:
  egress:
  - to:
    - ipBlock:
        cidr: 10.0.0.0/8
    - ipBlock:
        cidr: 172.16.0.0/12
    - ipBlock:
        cidr: 192.168.0.0/16
  ingress:
  - ports:
    - port: 44134
      protocol: TCP
    - port: 44135
      protocol: TCP
  podSelector:
    matchLabels:
      app: helm
      name: tiller
  policyTypes:
  - Egress
  - Ingress
```