### PR TITLE
Make max wait for EnsureTillerInstalled configurable

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -191,7 +191,6 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 
 	var err error
 	var installTiller bool
-	var maxWait time.Duration
 	var pod *corev1.Pod
 	var upgradeTiller bool
 
@@ -209,14 +208,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			return nil
 		}
 
-		// maxWait is configurable so we can use more time in e2e tests
-		// than in operators.
-		maxWait, err = time.ParseDuration(c.ensureTillerInstalledMaxWait)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		b := backoff.NewConstant(maxWait, 3*time.Second)
+		b := backoff.NewConstant(c.ensureTillerInstalledMaxWait, 3*time.Second)
 		n := backoff.NewNotifier(c.logger, context.Background())
 
 		err = backoff.RetryNotify(o, b, n)

--- a/error.go
+++ b/error.go
@@ -186,15 +186,6 @@ func IsTestReleaseTimeout(err error) bool {
 	return microerror.Cause(err) == testReleaseTimeoutError
 }
 
-var tillerInstallationFailedError = &microerror.Error{
-	Kind: "tillerInstallationFailedError",
-}
-
-// IsTillerInstallationFailed asserts tillerInstallationFailedError.
-func IsTillerInstallationFailed(err error) bool {
-	return microerror.Cause(err) == tillerInstallationFailedError
-}
-
 var tillerNotFoundError = &microerror.Error{
 	Kind: "tillerNotFoundError",
 }

--- a/helmclient.go
+++ b/helmclient.go
@@ -52,7 +52,7 @@ type Config struct {
 	K8sClient  kubernetes.Interface
 	Logger     micrologger.Logger
 
-	EnsureTillerInstalledMaxWait string
+	EnsureTillerInstalledMaxWait time.Duration
 	RestConfig                   *rest.Config
 	TillerImage                  string
 	TillerNamespace              string
@@ -66,7 +66,7 @@ type Client struct {
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
 
-	ensureTillerInstalledMaxWait string
+	ensureTillerInstalledMaxWait time.Duration
 	restConfig                   *rest.Config
 	tillerImage                  string
 	tillerNamespace              string
@@ -84,7 +84,7 @@ func New(config Config) (*Client, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
 
-	if config.EnsureTillerInstalledMaxWait == "" {
+	if config.EnsureTillerInstalledMaxWait == 0 {
 		config.EnsureTillerInstalledMaxWait = defaultEnsureTillerInstalledMaxWait
 	}
 	if config.RestConfig == nil {

--- a/helmclient.go
+++ b/helmclient.go
@@ -84,12 +84,11 @@ func New(config Config) (*Client, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
 
-	if config.RestConfig == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.RestConfig must not be empty", config)
-	}
-
 	if config.EnsureTillerInstalledMaxWait == "" {
 		config.EnsureTillerInstalledMaxWait = defaultEnsureTillerInstalledMaxWait
+	}
+	if config.RestConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RestConfig must not be empty", config)
 	}
 	if config.TillerImage == "" {
 		config.TillerImage = defaultTillerImage
@@ -110,10 +109,10 @@ func New(config Config) (*Client, error) {
 		k8sClient:  config.K8sClient,
 		logger:     config.Logger,
 
-		restConfig:      config.RestConfig,
-		tillerNamespace: config.TillerNamespace,
-
-		tillerImage: config.TillerImage,
+		ensureTillerInstalledMaxWait: config.EnsureTillerInstalledMaxWait,
+		restConfig:                   config.RestConfig,
+		tillerImage:                  config.TillerImage,
+		tillerNamespace:              config.TillerNamespace,
 	}
 
 	return c, nil

--- a/helmclient.go
+++ b/helmclient.go
@@ -52,9 +52,10 @@ type Config struct {
 	K8sClient  kubernetes.Interface
 	Logger     micrologger.Logger
 
-	RestConfig      *rest.Config
-	TillerImage     string
-	TillerNamespace string
+	EnsureTillerInstalledMaxWait string
+	RestConfig                   *rest.Config
+	TillerImage                  string
+	TillerNamespace              string
 }
 
 // Client knows how to talk with a Helm Tiller server.
@@ -65,9 +66,10 @@ type Client struct {
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
 
-	restConfig      *rest.Config
-	tillerImage     string
-	tillerNamespace string
+	ensureTillerInstalledMaxWait string
+	restConfig                   *rest.Config
+	tillerImage                  string
+	tillerNamespace              string
 }
 
 // New creates a new configured Helm client.
@@ -86,6 +88,9 @@ func New(config Config) (*Client, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.RestConfig must not be empty", config)
 	}
 
+	if config.EnsureTillerInstalledMaxWait == "" {
+		config.EnsureTillerInstalledMaxWait = defaultEnsureTillerInstalledMaxWait
+	}
 	if config.TillerImage == "" {
 		config.TillerImage = defaultTillerImage
 	}

--- a/helmclient_test.go
+++ b/helmclient_test.go
@@ -488,7 +488,7 @@ func Test_Client_ListReleaseContents(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(result, tc.expectedContents) {
-				t.Fatalf("Releases == %q, want %q", result, tc.expectedContents)
+				t.Fatalf("Releases == %#v, want %#v", result, tc.expectedContents)
 			}
 		})
 	}

--- a/spec.go
+++ b/spec.go
@@ -2,6 +2,7 @@ package helmclient
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/helm/pkg/helm"
 )
@@ -9,7 +10,7 @@ import (
 const (
 	// defaultEnsureTillerInstalledMaxWait is how long to wait in
 	// EnsureTillerInstalled to get a running tiller pod.
-	defaultEnsureTillerInstalledMaxWait = "1m"
+	defaultEnsureTillerInstalledMaxWait = 1 * time.Minute
 
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.

--- a/spec.go
+++ b/spec.go
@@ -7,6 +7,10 @@ import (
 )
 
 const (
+	// defaultEnsureTillerInstalledMaxWait is how long to wait in
+	// EnsureTillerInstalled to get a running tiller pod.
+	defaultEnsureTillerInstalledMaxWait = "1m"
+
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.
 	defaultMaxHistory = 10

--- a/spec.go
+++ b/spec.go
@@ -9,7 +9,7 @@ import (
 const (
 	// defaultEnsureTillerInstalledMaxWait is how long to wait in
 	// EnsureTillerInstalled to get a running tiller pod.
-	defaultEnsureTillerInstalledMaxWait = "1m"
+	defaultEnsureTillerInstalledMaxWait = "60s"
 
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.

--- a/spec.go
+++ b/spec.go
@@ -9,7 +9,7 @@ import (
 const (
 	// defaultEnsureTillerInstalledMaxWait is how long to wait in
 	// EnsureTillerInstalled to get a running tiller pod.
-	defaultEnsureTillerInstalledMaxWait = "60s"
+	defaultEnsureTillerInstalledMaxWait = "1m"
 
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.

--- a/spec.go
+++ b/spec.go
@@ -18,6 +18,7 @@ const (
 	defaultTillerImage     = "quay.io/giantswarm/tiller:v2.12.0"
 	defaultTillerNamespace = "kube-system"
 	roleBindingNamePrefix  = "tiller"
+	tillerFieldSelector    = "status.phase=Running"
 	tillerLabelSelector    = "app=helm,name=tiller"
 	tillerPodName          = "tiller-giantswarm"
 	tillerPort             = 44134


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6561

This is the other change needed. It improves the backoff handling and makes the max wait configurable. We keep the default 60 seconds for e2e tests.