### PR TITLE
When getting the tiller pod check that it is running

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -196,7 +196,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 
 	{
 		o := func() error {
-			pod, err = getPod(c.k8sClient, tillerLabelSelector, c.tillerNamespace)
+			pod, err = getPod(c.k8sClient, c.tillerNamespace)
 			if IsNotFound(err) {
 				// Fall through as we need to install Tiller.
 				installTiller = true

--- a/helmclient.go
+++ b/helmclient.go
@@ -662,7 +662,7 @@ func (c *Client) newTunnel() (*k8sportforward.Tunnel, error) {
 
 	pod, err := getPod(c.k8sClient, c.tillerNamespace)
 	if IsNotFound(err) {
-		return nil, microerror.Maskf(tillerNotFoundError, "label selector: %#q namespace: %#q", tillerLabelSelector, c.tillerNamespace)
+		return nil, microerror.Maskf(tillerNotFoundError, "field selector: %#q label selector: %#q namespace: %#q", runningPodFieldSelector, tillerLabelSelector, c.tillerNamespace)
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -723,7 +723,7 @@ func filterList(rels []*hapirelease.Release) []*hapirelease.Release {
 
 func getPod(client kubernetes.Interface, namespace string) (*corev1.Pod, error) {
 	o := metav1.ListOptions{
-		FieldSelector: tillerFieldSelector,
+		FieldSelector: runningPodFieldSelector,
 		LabelSelector: tillerLabelSelector,
 	}
 	pods, err := client.CoreV1().Pods(namespace).List(o)

--- a/helmclient_test.go
+++ b/helmclient_test.go
@@ -488,7 +488,7 @@ func Test_Client_ListReleaseContents(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(result, tc.expectedContents) {
-				t.Fatalf("Releases == %q, want %q", result, tc.expectedContents)
+				t.Fatalf("Releases == %#v, want %#v", result, tc.expectedContents)
 			}
 		})
 	}

--- a/spec.go
+++ b/spec.go
@@ -15,13 +15,13 @@ const (
 	// runReleaseTestTimeout is the timeout in seconds when running tests.
 	runReleaseTestTimout = 300
 
-	defaultTillerImage     = "quay.io/giantswarm/tiller:v2.12.0"
-	defaultTillerNamespace = "kube-system"
-	roleBindingNamePrefix  = "tiller"
-	tillerFieldSelector    = "status.phase=Running"
-	tillerLabelSelector    = "app=helm,name=tiller"
-	tillerPodName          = "tiller-giantswarm"
-	tillerPort             = 44134
+	defaultTillerImage      = "quay.io/giantswarm/tiller:v2.12.0"
+	defaultTillerNamespace  = "kube-system"
+	roleBindingNamePrefix   = "tiller"
+	runningPodFieldSelector = "status.phase=Running"
+	tillerLabelSelector     = "app=helm,name=tiller"
+	tillerPodName           = "tiller-giantswarm"
+	tillerPort              = 44134
 )
 
 // Interface describes the methods provided by the helm client.

--- a/spec.go
+++ b/spec.go
@@ -18,6 +18,7 @@ const (
 	defaultTillerImage     = "quay.io/giantswarm/tiller:v2.12.0"
 	defaultTillerNamespace = "kube-system"
 	roleBindingNamePrefix  = "tiller"
+	tillerFieldSelector    = "status.phase=Running"
 	tillerLabelSelector    = "app=helm,name=tiller"
 	tillerPodName          = "tiller-giantswarm"
 	tillerPort             = 44134


### PR DESCRIPTION
Towards giantswarm/giantswarm#6561

First in a series of improvements to helmclient and cluster-operator to resolve this PM.

We use a port forwarding connection to talk to the Tiller API over gRPC. Now we check when we get the tiller pod that it is running.

```
k get po -n giantswarm
NAME                            READY   STATUS        RESTARTS   AGE
chart-operator-c48677b-rlbmx    1/1     Running       0          16h
tiller-deploy-86755bb48-5p6gq   0/1     Terminating   1          4h48m
tiller-deploy-86755bb48-865dw   0/1     Pending       0          4h30m
```
