### PR TITLE
Add podsecuritypolicy for Tiller

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -127,6 +127,11 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 	{
 		name := fmt.Sprintf("%s-psp", tillerPodName)
 
+		apiGroups     := []string{"extensions"}
+		resources     := []string{"podsecuritypolicies"}
+		resourceNames := []string{name}
+		verbs         := []string{"use"}
+
 		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrole %#q", name))
 
 		cr := &rbacv1.ClusterRole{
@@ -139,18 +144,10 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{
-						"extensions",
-					},
-					Resources: []string{
-						"podsecuritypolicies",
-					},
-					ResourceNames: []string{
-						name,
-					},
-					Verbs: []string{
-						"use",
-					},
+					APIGroups:     apiGroups,
+					Resources:     resources,
+					ResourceNames: resourceNames,
+					Verbs:         verbs,
 				},
 			},
 		}

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -213,12 +213,8 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 	{
 		podSecurityPolicyName := tillerPodName + "-psp"
 		podSecurityPolicyNamespace := c.tillerNamespace
-		minRunAsID := intstr.IntOrString{
-			IntVal: 1,
-		}
-		maxRunAsID := intstr.IntOrString{
-			IntVal: 65535,
-		}
+		minRunAsID := 1
+		maxRunAsID := 65535
 
 		name := fmt.Sprintf("%s-psp", tillerPodName)
 

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -139,16 +139,16 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups := []string{
+					APIGroups: []string{
 						"extensions",
 					},
-					Resources := []string{
+					Resources: []string{
 						"podsecuritypolicies",
 					},
-					ResourceNames := []string{
+					ResourceNames: []string{
 						name,
 					},
-					Verbs := []string{
+					Verbs: []string{
 						"use",
 					},
 				},

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -139,13 +139,13 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups:
+					[]APIGroups:
 						"extensions",
-					Resources:
+					[]Resources:
 						"podsecuritypolicies",
-					ResourceNames:
+					[]ResourceNames:
 						name,
-					Verbs:
+					[]Verbs:
 						"use",
 				},
 			},
@@ -207,7 +207,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 
 	// create a pod security policy for tiller to ensure it runs with least possible privileges.
 	{
-		podSecurityPolicyName = tillerPodName + "-psp"
+		podSecurityPolicyName := tillerPodName + "-psp"
 		podSecurityPolicyNamespace := c.tillerNamespace
 		minRunAsID := intstr.IntOrString{
 			IntVal: 1,
@@ -215,7 +215,6 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		maxRunAsID := intstr.IntOrString{
 			IntVal: 65535,
 		}
-		privilegedPod := false
 
 		name := fmt.Sprintf("%s-psp", tillerPodName)
 
@@ -231,7 +230,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 				Namespace: podSecurityPolicyNamespace,
 			},
 			Spec: extensionsv1beta1.PodSecurityPolicySpec{
-				Privileged: &privilegedPod,
+				Privileged: false,
 				Volumes: []extensionsv1beta1.FSType{
 					"secret",
 				},
@@ -265,7 +264,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 						Max: &maxRunAsID,
 					},
 				},
-				AllowPrivilegeEscalation: &privilegedPod,
+				AllowPrivilegeEscalation: false,
 			},
 		}
 

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -139,14 +139,18 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					[]APIGroups:
+					APIGroups{
 						"extensions",
-					[]Resources:
+					},
+					Resources{
 						"podsecuritypolicies",
-					[]ResourceNames:
+					},
+					ResourceNames{
 						name,
-					[]Verbs:
+					},
+					Verbs{
 						"use",
+					},
 				},
 			},
 		}

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -230,15 +230,24 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 				Namespace: podSecurityPolicyNamespace,
 			},
 			Spec: policyv1beta1.PodSecurityPolicySpec{
-				Privileged: false,
-				Volumes: []policyv1beta1.FSType{
-					"secret",
+				AllowPrivilegeEscalation: false,
+				FSGroup: []policyv1beta1.FSGroupStrategyOptions{
+					Rule: FSGroupStrategyMustRunAs,
+					Ranges: []policyv1beta1.IDRange{
+						Min: &minRunAsID,
+						Max: &maxRunAsID,
+					},
 				},
+				HostIPC:     false,
 				HostNetwork: false,
 				HostPID:     false,
-				HostIPC:     false,
-				SELinux: []policyv1beta1.SELinuxStrategyOptions{
-					Rule: SELinuxStrategyRunAsAny,
+				Privileged:  false,
+				RunAsGroup: []policyv1beta1.RunAsGroupStrategyOptions{
+					Rule: RunAsGroupStrategyMayRunAs,
+					Ranges: []policyv1beta1.IDRange{
+						Min: &minRunAsID,
+						Max: &maxRunAsID,
+					},
 				},
 				RunAsUser: []policyv1beta1.RunAsUserStrategyOptions{
 					Rule: RunAsUserStrategyMustRunAs,
@@ -247,24 +256,15 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 						Max: &maxRunAsID,
 					},
 				},
-				RunAsGroup: []policyv1beta1.RunAsGroupStrategyOptions{
-					Rule: RunAsGroupStrategyMayRunAs,
-					Ranges: []policyv1beta1.IDRange{
-						Min: &minRunAsID,
-						Max: &maxRunAsID,
-					},
+				SELinux: []policyv1beta1.SELinuxStrategyOptions{
+					Rule: SELinuxStrategyRunAsAny,
 				},
 				SupplementalGroups: []policyv1beta1.SupplementalGroupsStrategyOptions{
 					Rule: SupplementalGroupsStrategyRunAsAny,
 				},
-				FSGroup: []policyv1beta1.FSGroupStrategyOptions{
-					Rule: FSGroupStrategyMustRunAs,
-					Ranges: []policyv1beta1.IDRange{
-						Min: &minRunAsID,
-						Max: &maxRunAsID,
-					},
+				Volumes: []policyv1beta1.FSType{
+					"secret",
 				},
-				AllowPrivilegeEscalation: false,
 			},
 		}
 

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -9,8 +9,8 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -220,46 +220,46 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 
 		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating podsecuritypolicy %#q", name))
 
-		psp := &extensionsv1beta1.PodSecurityPolicy{
+		psp := &policyv1beta1.PodSecurityPolicy{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "extensions/v1beta1",
+				APIVersion: "policy/v1beta1",
 				Kind:       "PodSecurityPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      podSecurityPolicyName,
 				Namespace: podSecurityPolicyNamespace,
 			},
-			Spec: extensionsv1beta1.PodSecurityPolicySpec{
+			Spec: policyv1beta1.PodSecurityPolicySpec{
 				Privileged: false,
-				Volumes: []extensionsv1beta1.FSType{
+				Volumes: []policyv1beta1.FSType{
 					"secret",
 				},
 				HostNetwork: false,
 				HostPID:     false,
 				HostIPC:     false,
-				SELinux: []extensionsv1beta1.SELinuxStrategyOptions{
+				SELinux: []policyv1beta1.SELinuxStrategyOptions{
 					Rule: SELinuxStrategyRunAsAny,
 				},
-				RunAsUser: []extensionsv1beta1.RunAsUserStrategyOptions{
+				RunAsUser: []policyv1beta1.RunAsUserStrategyOptions{
 					Rule: RunAsUserStrategyMustRunAs,
-					Ranges: []extensionsv1beta1.IDRange{
+					Ranges: []policyv1beta1.IDRange{
 						Min: &minRunAsID,
 						Max: &maxRunAsID,
 					},
 				},
-				RunAsGroup: []extensionsv1beta1.RunAsGroupStrategyOptions{
+				RunAsGroup: []policyv1beta1.RunAsGroupStrategyOptions{
 					Rule: RunAsGroupStrategyMayRunAs,
-					Ranges: []extensionsv1beta1.IDRange{
+					Ranges: []policyv1beta1.IDRange{
 						Min: &minRunAsID,
 						Max: &maxRunAsID,
 					},
 				},
-				SupplementalGroups: []extensionsv1beta1.SupplementalGroupsStrategyOptions{
+				SupplementalGroups: []policyv1beta1.SupplementalGroupsStrategyOptions{
 					Rule: SupplementalGroupsStrategyRunAsAny,
 				},
-				FSGroup: []extensionsv1beta1.FSGroupStrategyOptions{
+				FSGroup: []policyv1beta1.FSGroupStrategyOptions{
 					Rule: FSGroupStrategyMustRunAs,
-					Ranges: []extensionsv1beta1.IDRange{
+					Ranges: []policyv1beta1.IDRange{
 						Min: &minRunAsID,
 						Max: &maxRunAsID,
 					},
@@ -268,7 +268,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			},
 		}
 
-		_, err := c.k8sClient.ExtensionsV1beta1().PodSecurityPolicies().Create(psp)
+		_, err := c.k8sClient.PolicyV1beta1().PodSecurityPolicies().Create(psp)
 		if errors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("podsecuritypolicy %#q already exists", name))
 			// fall through

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -139,16 +139,16 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups{
+					APIGroups := []string{
 						"extensions",
 					},
-					Resources{
+					Resources := []string{
 						"podsecuritypolicies",
 					},
-					ResourceNames{
+					ResourceNames := []string{
 						name,
 					},
-					Verbs{
+					Verbs := []string{
 						"use",
 					},
 				},


### PR DESCRIPTION
This PR adds a clusterrole, clusterrolebinding and a podsecuritypolicy for Tiller. 

My Go experience is relatively limited (especially so when using client_go) so please expect to have to point me in the right direction - I wouldn't expect this to be the finished article. It is currently untested as I wanted to get a first-pass from someone with more knowledge than myself. 

Provided the resources are created correctly, Tiller should continue to work fine with the PSP in place. It currently runs as `nobody/nogroup` and only requires access to secrets.