### PR TITLE
Pass nil when configmap values are empty

### DIFF
--- a/merge_values.go
+++ b/merge_values.go
@@ -108,6 +108,10 @@ func yamlToStringMap(input []byte) (map[string]interface{}, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	if raw == nil {
+		return nil, nil
+	}
+
 	inputMap, ok := raw.(map[interface{}]interface{})
 	if !ok {
 		return nil, microerror.Maskf(executionFailedError, "input type %T but expected %T", raw, inputMap)

--- a/merge_values.go
+++ b/merge_values.go
@@ -109,7 +109,8 @@ func yamlToStringMap(input []byte) (map[string]interface{}, error) {
 	}
 
 	if raw == nil {
-		return nil, nil
+		result := map[string]interface{}{}
+		return result, nil
 	}
 
 	inputMap, ok := raw.(map[interface{}]interface{})

--- a/merge_values_test.go
+++ b/merge_values_test.go
@@ -59,6 +59,9 @@ test: test`
 const nullValuedNestedKeyYaml = `
 nested: null`
 
+const nullValuedYaml = `
+null`
+
 func Test_MergeValues(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -164,6 +167,16 @@ func Test_MergeValues(t *testing.T) {
 				"nested": nil,
 				"test":   "test",
 			},
+		},
+		{
+			name: "case 9: null-value in src/dest",
+			destMap: map[string][]byte{
+				"simple": []byte(nullValuedYaml),
+			},
+			srcMap: map[string][]byte{
+				"override": []byte(nullValuedYaml),
+			},
+			expectedValues: map[string]interface{}(nil),
 		},
 	}
 

--- a/merge_values_test.go
+++ b/merge_values_test.go
@@ -176,7 +176,7 @@ func Test_MergeValues(t *testing.T) {
 			srcMap: map[string][]byte{
 				"override": []byte(nullValuedYaml),
 			},
-			expectedValues: map[string]interface{}(nil),
+			expectedValues: map[string]interface{}{},
 		},
 	}
 


### PR DESCRIPTION
app-operator had an issue with helmclient.MergeValues as below. 
```
E 10/01 08:20:29 /apis/application.giantswarm.io/v1alpha1/namespaces/zf3n9/apps/kubernetes-elastic-stack-elastic-logging configmapv1 stop reconciliation due to error | operatorkit/controller/controller.go:372 | controller=app-operator | event=update | loop=548 | version=141177095
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:553:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/crud_resource_wrapper.go:63:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_wrapper.go:82:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:91:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/crud_resource_ops_wrapper.go:70:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:102:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:89:
    /go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap/desired.go:33:
    /go/src/github.com/giantswarm/app-operator/service/controller/app/v1/values/configmap.go:43:
    /go/src/github.com/giantswarm/app-operator/service/controller/app/v1/values/configmap.go:116:
    /go/src/github.com/giantswarm/app-operator/service/controller/app/v1/values/values.go:72:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/merge_values.go:27:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/merge_values.go:55:
    /go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/merge_values.go:113: input type <nil> but expected map[interface {}]interface {}
    execution failed error
```

This is due to appCatalog does not contains any value inside of configMaps. 

```
kg get cm giantswarm-incubator -o yaml
apiVersion: v1
data:
  values: |
    null
kind: ConfigMap
metadata:
  creationTimestamp: "2019-07-11T13:32:46Z"
  name: giantswarm-incubator
  namespace: giantswarm
  resourceVersion: "139948242"
  selfLink: /api/v1/namespaces/giantswarm/configmaps/giantswarm-incubator
  uid: 5e3a08a5-a3e0-11e9-ac0f-000d3a43f713
```

This patch would pass `nil` value to TCs even if there is no value inside appCatalog. 