### PR TITLE
Return pull chart error type on when pulling failed

### DIFF
--- a/error.go
+++ b/error.go
@@ -86,6 +86,15 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
+var pullChartFailedError = &microerror.Error{
+	Kind: "pullChartFailedError",
+}
+
+// IsPullChartFailedError asserts pullChartFailedError.
+func IsPullChartFailedError(err error) bool {
+	return microerror.Cause(err) == pullChartFailedError
+}
+
 var (
 	releaseAlreadyExistsRegexp = regexp.MustCompile(`release named \S+ already exists`)
 )

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -37,7 +37,7 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 	o := func() error {
 		resp, err := c.httpClient.Do(req)
 		if isNoSuchHostError(err) {
-			return backoff.Permanent(microerror.Maskf(executionFailedError, "no such host %#q", req.Host))
+			return backoff.Permanent(microerror.Maskf(pullChartFailedError, "no such host %#q", req.Host))
 		} else if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -52,7 +52,7 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 			// Github pages 404 produces full HTML page which
 			// obscures the logs.
 			if resp.StatusCode == http.StatusNotFound {
-				return backoff.Permanent(microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
+				return backoff.Permanent(microerror.Maskf(pullChartFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
 			}
 			return microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q with body %s", resp.StatusCode, req.URL.String(), buf.String()))
 		}


### PR DESCRIPTION
Following https://github.com/giantswarm/chart-operator/pull/308#discussion_r338917401

> Is there a more specific error that we can match against? My thinking is that there is a specific case in which we really want to cancel. On the other hand there are cases which we do not expect and we should treat them like real errors.

