### PR TITLE
Renaming an tiller not running error

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -264,7 +264,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			if IsTillerNotFound(err) || IsTooManyResults(err) || IsTillerInvalidVersion(err) {
 				return microerror.Mask(err)
 			} else if err != nil {
-				return backoff.Permanent(microerror.Maskf(tillerStartingError, "can't establish  tunnel to tiller pod with error %#q", err))
+				return backoff.Permanent(microerror.Maskf(tillerNotRunningError, "can't establish tunnel to tiller pod with error %#q", err))
 			}
 			defer c.closeTunnel(ctx, t)
 

--- a/error.go
+++ b/error.go
@@ -186,13 +186,13 @@ func IsTestReleaseTimeout(err error) bool {
 	return microerror.Cause(err) == testReleaseTimeoutError
 }
 
-var tillerStartingError = &microerror.Error{
-	Kind: "tillerStartingError",
+var tillerNotRunningError = &microerror.Error{
+	Kind: "tillerNotRunningError",
 }
 
-// IsTillerStartingError asserts tillerStartingError.
-func IsTillerStartingError(err error) bool {
-	return microerror.Cause(err) == tillerStartingError
+// IsTillerNotRunningError asserts tillerNotRunningError.
+func IsTillerNotRunningError(err error) bool {
+	return microerror.Cause(err) == tillerNotRunningError
 }
 
 var tillerNotFoundError = &microerror.Error{


### PR DESCRIPTION
Following https://github.com/giantswarm/app-operator/pull/161#discussion_r339672545

> Pods do have a phase but it is running not started. I'd like us to align this with the upstream terminology.

