### PR TITLE
Use permanent backoff for too many tillers error

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -352,7 +352,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 				installTiller = true
 				return nil
 			} else if IsTooManyResults(err) {
-				return backoff.Permanent(err)
+				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
 			}

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -351,6 +351,8 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 				// Fall through as we need to install Tiller.
 				installTiller = true
 				return nil
+			} else if IsTooManyResults(err) {
+				return backoff.Permanent(err)
 			} else if err != nil {
 				return microerror.Mask(err)
 			}


### PR DESCRIPTION
Towards giantswarm/giantswarm#7603

When testing https://github.com/giantswarm/cluster-operator/pull/787 found a problem with the fix.

Due to the backoff the TooManyResults error is not returned. Getting it straight.