### PR TITLE
Make tiller image registry configurable

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -54,7 +54,8 @@ type Config struct {
 
 	EnsureTillerInstalledMaxWait time.Duration
 	RestConfig                   *rest.Config
-	TillerImage                  string
+	TillerImageName              string
+	TillerImageRegistry          string
 	TillerNamespace              string
 }
 
@@ -90,8 +91,11 @@ func New(config Config) (*Client, error) {
 	if config.RestConfig == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.RestConfig must not be empty", config)
 	}
-	if config.TillerImage == "" {
-		config.TillerImage = defaultTillerImage
+	if config.TillerImageName == "" {
+		config.TillerImageName = defaultTillerImageName
+	}
+	if config.TillerImageRegistry == "" {
+		config.TillerImageRegistry = defaultTillerImageRegistry
 	}
 	if config.TillerNamespace == "" {
 		config.TillerNamespace = defaultTillerNamespace
@@ -102,6 +106,9 @@ func New(config Config) (*Client, error) {
 		Timeout: time.Second * httpClientTimeout,
 	}
 
+	// Registry is configurable for AWS China.
+	tillerImage := fmt.Sprintf("%s/%s", config.TillerImageRegistry, config.TillerImageName)
+
 	c := &Client{
 		fs:         config.Fs,
 		helmClient: config.HelmClient,
@@ -111,7 +118,7 @@ func New(config Config) (*Client, error) {
 
 		ensureTillerInstalledMaxWait: config.EnsureTillerInstalledMaxWait,
 		restConfig:                   config.RestConfig,
-		tillerImage:                  config.TillerImage,
+		tillerImage:                  tillerImage,
 		tillerNamespace:              config.TillerNamespace,
 	}
 

--- a/helmclient_test.go
+++ b/helmclient_test.go
@@ -2,6 +2,7 @@ package helmclient
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -569,7 +570,7 @@ func Test_isTillerInvalidVersion(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Image: defaultTillerImage,
+							Image: fmt.Sprintf("%s/%s", defaultTillerImageRegistry, defaultTillerImageName),
 						},
 					},
 				},
@@ -670,7 +671,7 @@ func Test_isTillerInvalidVersion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateTillerVersion(tc.tillerPod, defaultTillerImage)
+			err := validateTillerVersion(tc.tillerPod, fmt.Sprintf("%s/%s", defaultTillerImageRegistry, defaultTillerImageName))
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:

--- a/spec.go
+++ b/spec.go
@@ -20,13 +20,14 @@ const (
 	// runReleaseTestTimeout is the timeout in seconds when running tests.
 	runReleaseTestTimout = 300
 
-	defaultTillerImage      = "quay.io/giantswarm/tiller:v2.14.3"
-	defaultTillerNamespace  = "kube-system"
-	roleBindingNamePrefix   = "tiller"
-	runningPodFieldSelector = "status.phase=Running"
-	tillerLabelSelector     = "app=helm,name=tiller"
-	tillerPodName           = "tiller-giantswarm"
-	tillerPort              = 44134
+	defaultTillerImageName     = "giantswarm/tiller:v2.14.3"
+	defaultTillerImageRegistry = "quay.io"
+	defaultTillerNamespace     = "kube-system"
+	roleBindingNamePrefix      = "tiller"
+	runningPodFieldSelector    = "status.phase=Running"
+	tillerLabelSelector        = "app=helm,name=tiller"
+	tillerPodName              = "tiller-giantswarm"
+	tillerPort                 = 44134
 )
 
 // Interface describes the methods provided by the helm client.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7773

In AWS China after the pause container the next image we hit on cluster creation is Tiller. So making it configurable for use in app-operator.