### PR TITLE
Migrate PSP API group use from deprecated extensions to policy

### DIFF
--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -140,7 +140,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{
-						"extensions",
+						"policy",
 					},
 					Resources: []string{
 						"podsecuritypolicies",


### PR DESCRIPTION
This PR minimizes https://github.com/giantswarm/helmclient/pull/134 with stuff that can be shipped independently from 1.16 upgrade, like the migration of long time deprecated API groups which are being dropped in 1.16.