### PR TITLE
Set host header to prevent 404 errors from GitHub pages

### DIFF
--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/giantswarm/backoff"
@@ -20,6 +21,14 @@ func (c *Client) PullChartTarball(ctx context.Context, tarballURL string) (strin
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
+
+	u, err := url.Parse(tarballURL)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	// Set host header to prevent 404 responses from GitHub Pages.
+	req.Host = u.Host
 
 	chartTarballPath, err := c.doFile(ctx, req)
 	if err != nil {
@@ -49,11 +58,12 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			// Github pages 404 produces full HTML page which
-			// obscures the logs.
+
+			// Github Pages 404 produces full HTML page which obscures the logs.
 			if resp.StatusCode == http.StatusNotFound {
 				return backoff.Permanent(microerror.Maskf(pullChartFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
 			}
+
 			return microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q with body %s", resp.StatusCode, req.URL.String(), buf.String()))
 		}
 


### PR DESCRIPTION
This is to try and fix the 404 errors we've been seeing pulling chart tarballs. These eventually clear but it takes a long time and is super annoying.

@TheoBrigitte was able to repro with curl by setting an empty host header. So this sets the header once we've created the request.

See https://gigantic.slack.com/archives/C76JX6YLQ/p1576590423053600

