### PR TITLE
Handle additional errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ e2eTest: &e2eTest
     - run:
         name: Get helm binary
         command: |
-          curl -L https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz | tar xvz --strip-components 1 linux-amd64/helm
+          curl -L https://get.helm.sh/helm-v2.16.0-linux-amd64.tar.gz | tar xvz --strip-components 1 linux-amd64/helm
           chmod +x helm
 
     - run:
@@ -34,7 +34,7 @@ e2eTest: &e2eTest
           then
             export KUBECONFIG=$(./e2ectl kubeconfig path)
             ./kubectl create ns giantswarm
-            ./helm init --tiller-namespace giantswarm --tiller-image quay.io/giantswarm/tiller:v2.14.3 --wait
+            ./helm init --tiller-namespace giantswarm --tiller-image quay.io/giantswarm/tiller:v2.16.0 --wait
           fi
 
     - run:

--- a/error.go
+++ b/error.go
@@ -33,6 +33,32 @@ func IsCannotReuseRelease(err error) bool {
 	return false
 }
 
+var (
+	emptyChartTemplatesRegexp = regexp.MustCompile(`release \S+ failed: no objects visited`)
+)
+
+var emptyChartTemplatesError = &microerror.Error{
+	Kind: "emptyChartTemplatesError",
+}
+
+// IsEmptyChartTemplates asserts emptyChartTemplatesError.
+func IsEmptyChartTemplates(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == emptyChartTemplatesError {
+		return true
+	}
+	if emptyChartTemplatesRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}
+
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
@@ -124,6 +150,62 @@ func IsReleaseAlreadyExists(err error) bool {
 		return true
 	}
 	if releaseAlreadyExistsRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}
+
+const (
+	releaseNameInvalidErrorPrefix = "invalid release name"
+	releaseNameInvalidErrorSuffix = "and the length must not be longer than 53"
+)
+
+var releaseNameInvalidError = &microerror.Error{
+	Kind: "releaseNameInvalidError",
+}
+
+// IsReleaseNameInvalid asserts releaseNameInvalidError.
+func IsReleaseNameInvalid(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasPrefix(c.Error(), releaseNameInvalidErrorPrefix) {
+		return true
+	}
+	if strings.HasSuffix(c.Error(), releaseNameInvalidErrorSuffix) {
+		return true
+	}
+	if c == releaseNameInvalidError {
+		return true
+	}
+
+	return false
+}
+
+const (
+	releaseNotDeployedErrorSuffix = "has no deployed releases"
+)
+
+var releaseNotDeployedError = &microerror.Error{
+	Kind: "releaseNotDeployedError",
+}
+
+// IsReleaseNotDeployed asserts releaseNotDeployedError.
+func IsReleaseNotDeployed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasSuffix(c.Error(), releaseNotDeployedErrorSuffix) {
+		return true
+	}
+	if c == releaseNotDeployedError {
 		return true
 	}
 

--- a/helmclient.go
+++ b/helmclient.go
@@ -201,6 +201,10 @@ func (c *Client) getReleaseContent(ctx context.Context, releaseName string) (*Re
 			t, err := c.newTunnel()
 			if IsTillerNotFound(err) {
 				return backoff.Permanent(microerror.Mask(err))
+			} else if IsEmptyChartTemplates(err) {
+				return backoff.Permanent(microerror.Mask(err))
+			} else if IsReleaseNameInvalid(err) {
+				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
 			}
@@ -347,6 +351,8 @@ func (c *Client) installReleaseFromTarball(ctx context.Context, path, ns string,
 		if IsCannotReuseRelease(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsReleaseAlreadyExists(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsTarballNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
@@ -600,7 +606,11 @@ func (c *Client) updateReleaseFromTarball(ctx context.Context, releaseName, path
 		defer c.closeTunnel(ctx, t)
 
 		release, err := c.newHelmClientFromTunnel(t).UpdateRelease(releaseName, path, options...)
-		if IsReleaseNotFound(err) {
+		if IsReleaseNotDeployed(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsReleaseNotFound(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsYamlConversionFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7355

Handles additional error cases. Used in https://github.com/giantswarm/chart-operator/pull/343.

- Chart tarball has an empty templates directory.
- Helm release name is invalid.
- Helm release is not deployed.
