### PR TITLE
Handle timeouts pulling charts and add monitoring

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package helmclient
 
 import (
+	"net"
 	"regexp"
 	"strings"
 
@@ -128,6 +129,34 @@ var pullChartNotFoundError = &microerror.Error{
 // IsPullChartNotFound asserts pullChartNotFoundError.
 func IsPullChartNotFound(err error) bool {
 	return microerror.Cause(err) == pullChartNotFoundError
+}
+
+var pullChartTimeoutError = &microerror.Error{
+	Kind: "pullChartTimeoutError",
+}
+
+// IsPullChartTimeout asserts pullChartTimeoutError.
+func IsPullChartTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == pullChartTimeoutError {
+		return true
+	}
+
+	netErr, ok := err.(net.Error)
+	if !ok {
+		return false
+	}
+
+	if netErr.Timeout() {
+		return true
+	}
+
+	return false
 }
 
 var (

--- a/error.go
+++ b/error.go
@@ -152,11 +152,7 @@ func IsPullChartTimeout(err error) bool {
 		return false
 	}
 
-	if netErr.Timeout() {
-		return true
-	}
-
-	return false
+	return netErr.Timeout()
 }
 
 var (

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -64,7 +64,7 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 		if isNoSuchHostError(err) {
 			return backoff.Permanent(microerror.Maskf(pullChartFailedError, "no such host %#q", req.Host))
 		} else if IsPullChartTimeout(err) {
-			return backoff.Permanent(microerror.Maskf(pullChartTimeoutError, "%#q for url %#q", req.Method, req.URL.String()))
+			return backoff.Permanent(microerror.Maskf(pullChartTimeoutError, "%#q timeout for %#q", req.Method, req.URL.String()))
 		} else if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -63,6 +63,8 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 		resp, err := c.httpClient.Do(req)
 		if isNoSuchHostError(err) {
 			return backoff.Permanent(microerror.Maskf(pullChartFailedError, "no such host %#q", req.Host))
+		} else if IsPullChartTimeout(err) {
+			return backoff.Permanent(microerror.Maskf(pullChartTimeoutError, "%#q for url %#q", req.Method, req.URL.String()))
 		} else if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -11,12 +11,28 @@ import (
 
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
 )
 
 // PullChartTarball downloads a tarball from the provided tarball URL,
 // returning the file path.
 func (c *Client) PullChartTarball(ctx context.Context, tarballURL string) (string, error) {
+	eventName := "pull_chart_tarball"
+
+	t := prometheus.NewTimer(histogram.WithLabelValues(eventName))
+	defer t.ObserveDuration()
+
+	chartTarballPath, err := c.pullChartTarball(ctx, tarballURL)
+	if err != nil {
+		errorGauge.WithLabelValues(eventName).Inc()
+		return "", microerror.Mask(err)
+	}
+
+	return chartTarballPath, nil
+}
+
+func (c *Client) pullChartTarball(ctx context.Context, tarballURL string) (string, error) {
 	req, err := c.newRequest("GET", tarballURL)
 	if err != nil {
 		return "", microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8573

Adds missing monitoring to PullChartTarball and handles timeout errors which we see sometimes in multiple installations.