### PR TITLE
Use context.WithTimeout to limit time connecting to tiller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -273,12 +273,12 @@
   revision = "6cb127468cd6b30eaf8030b875f796e34b481938"
 
 [[projects]]
-  branch = "master"
-  digest = "1:42649fa57594fd0dd202a5cf01d9cae946ff99e0e8f87bc9c145860a2e57c17a"
+  branch = "tiller-again"
+  digest = "1:9e8169250bfc3d50e6486b4f68e81b2811ed8a241e5778573f4308633f756fb5"
   name = "github.com/giantswarm/k8sportforward"
   packages = ["."]
   pruneopts = "UT"
-  revision = "676e7106283c008acc4c07c0cfc903c18cdbeda3"
+  revision = "5553c56577e8343dc7eff94d75e44bd3d46f9846"
 
 [[projects]]
   branch = "master"
@@ -1584,6 +1584,7 @@
     "k8s.io/api/networking/v1",
     "k8s.io/api/policy/v1beta1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/api/scheduling/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/util/intstr",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,9 +54,9 @@ required = [
   name = "github.com/giantswarm/errors"
   branch = "master"
 
-[[constraint]]
+[[override]]
   name = "github.com/giantswarm/k8sportforward"
-  branch = "master"
+  branch = "tiller-again"
 
 [[constraint]]
   name = "github.com/giantswarm/microerror"

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -41,7 +41,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 
 		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding if tiller is installed in namespace %#q", c.tillerNamespace))
 
-		t, err := c.newTunnel()
+		t, err := c.newTunnel(ctx)
 		defer c.closeTunnel(ctx, t)
 		if err != nil {
 			// fall through, we may need to create or upgrade Tiller.
@@ -455,7 +455,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		var i int
 
 		o := func() error {
-			t, err := c.newTunnel()
+			t, err := c.newTunnel(ctx)
 			if IsTillerNotFound(err) || IsTooManyResults(err) || IsTillerInvalidVersion(err) {
 				return microerror.Mask(err)
 			} else if err != nil {

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -36,7 +36,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []string) error {
 	// Check if Tiller is already present and return early if so.
 	{
-		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
 		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding if tiller is installed in namespace %#q", c.tillerNamespace))
@@ -54,6 +54,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			}
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			c.logger.LogCtx(ctx, "level", "debug", "message", "timeout finding if tiller is installed")
 			return microerror.Maskf(tillerNotFoundError, ctx.Err().Error())
 		}
 	}

--- a/ensure_tiller_installed.go
+++ b/ensure_tiller_installed.go
@@ -2,6 +2,7 @@ package helmclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/helm/cmd/helm/installer"
@@ -35,6 +36,9 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []string) error {
 	// Check if Tiller is already present and return early if so.
 	{
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
 		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding if tiller is installed in namespace %#q", c.tillerNamespace))
 
 		t, err := c.newTunnel()
@@ -48,6 +52,9 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 				c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found that tiller is installed in namespace %#q", c.tillerNamespace))
 				return nil
 			}
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return microerror.Maskf(tillerNotFoundError, ctx.Err().Error())
 		}
 	}
 
@@ -70,7 +77,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.CoreV1().ServiceAccounts(namespace).Create(serviceAccont)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("serviceaccount %#q in namespace %#q already exists", name, namespace))
 			// fall through
 		} else if tenant.IsAPINotAvailable(err) {
@@ -114,7 +121,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.RbacV1().ClusterRoleBindings().Create(i)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q already exists", name))
 			// fall through
 		} else if err != nil {
@@ -157,7 +164,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.RbacV1().ClusterRoles().Create(cr)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q already exists", name))
 			// fall through
 		} else if err != nil {
@@ -199,7 +206,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.RbacV1().ClusterRoleBindings().Create(crb)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q already exists", name))
 			// fall through
 		} else if err != nil {
@@ -263,7 +270,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.PolicyV1beta1().PodSecurityPolicies().Create(psp)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("podsecuritypolicy %#q already exists", name))
 			// fall through
 		} else if err != nil {
@@ -330,7 +337,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.NetworkingV1().NetworkPolicies(networkPolicyNamespace).Create(np)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("networkpolicy %#q already exists", name))
 			// fall through
 		} else if err != nil {
@@ -360,7 +367,7 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 
 		_, err := c.k8sClient.SchedulingV1().PriorityClasses().Create(pc)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("priorityclass %#q already exists", priorityClassName))
 			// fall through
 		} else if err != nil {
@@ -487,7 +494,7 @@ func (c *Client) installTiller(ctx context.Context, installerOptions *installer.
 
 	o := func() error {
 		err := installer.Install(c.k8sClient, installerOptions)
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tiller in namespace %#q already exists", c.tillerNamespace))
 			// fall through
 		} else if err != nil {

--- a/vendor/github.com/giantswarm/k8sportforward/Gopkg.lock
+++ b/vendor/github.com/giantswarm/k8sportforward/Gopkg.lock
@@ -101,7 +101,7 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "ac88ee75c92c889b97e05591e9a39b6480c538b3"
+  revision = "e9b2fee46413994441b28dfca259d911d963dfed"
 
 [[projects]]
   branch = "master"
@@ -116,29 +116,29 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "ef20fe5d793301b553005db740f730d87993f778"
+  revision = "c0dbc17a35534bf2e581d7a942408dc936316da4"
 
 [[projects]]
   branch = "master"
-  digest = "1:8d1c112fb1679fa097e9a9255a786ee47383fa2549a3da71bcb1334a693ebcfe"
+  digest = "1:55d36eb35766a3f105fa36cfb2faf053cc33c019108a6adee799c4e7d59d62b2"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "5d9234df094ce600ff541158d1491aa10d078a47"
+  revision = "858c2ad4c8b6c5d10852cb89079f6ca1c7309787"
 
 [[projects]]
   branch = "master"
-  digest = "1:055d921edfad0ae56ef0d21a124a002cf3a669b4c42e85b810abf0225226e2a3"
+  digest = "1:8191c209ac2aaba9e958a061256fab8955ad10cc731aa609660184800f1ef55a"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "63cb32ae39b28d6bb8e7e215c1fc39dd80dcdb02"
+  revision = "eeba5f6aabab6d6594a9191d6bfeaca5fa6a8248"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"

--- a/vendor/github.com/giantswarm/k8sportforward/forwarder.go
+++ b/vendor/github.com/giantswarm/k8sportforward/forwarder.go
@@ -1,6 +1,7 @@
 package k8sportforward
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/giantswarm/microerror"
@@ -40,7 +41,7 @@ func NewForwarder(config ForwarderConfig) (*Forwarder, error) {
 }
 
 // ForwardPort opens a tunnel to a kubernetes pod.
-func (f *Forwarder) ForwardPort(namespace string, podName string, remotePort int) (*Tunnel, error) {
+func (f *Forwarder) ForwardPort(ctx context.Context, namespace string, podName string, remotePort int) (*Tunnel, error) {
 	transport, upgrader, err := spdy.RoundTripperFor(f.restConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -61,7 +62,7 @@ func (f *Forwarder) ForwardPort(namespace string, podName string, remotePort int
 		RemotePort: remotePort,
 	}
 
-	tunnel, err := newTunnel(config)
+	tunnel, err := newTunnel(ctx, config)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/vendor/github.com/giantswarm/k8sportforward/tunnel.go
+++ b/vendor/github.com/giantswarm/k8sportforward/tunnel.go
@@ -28,7 +28,7 @@ type Tunnel struct {
 	stopChan  chan struct{}
 }
 
-func newTunnel(config tunnelConfig) (*Tunnel, error) {
+func newTunnel(ctx context.Context, config tunnelConfig) (*Tunnel, error) {
 	p, err := getAvailablePort()
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -52,7 +52,7 @@ func newTunnel(config tunnelConfig) (*Tunnel, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8479

This looks fine tested locally but I want to test tomorrow with my nemesis `asgard/f24sd`. To make sure it's fixed this time.

```
D 01/29 17:22:58 /apis/application.giantswarm.io/v1alpha1/namespaces/f24sd/apps/chart-operator tillerv1 finding if tiller is installed in namespace `giantswarm` | helmclient/ensure_tiller_installed.go:38 | controller=app-operator | event=update | loop=52077 | version=186624200
D 01/29 17:42:58 /apis/application.giantswarm.io/v1alpha1/namespaces/f24sd/apps/chart-operator tillerv1 found that tiller is not installed in namespace `giantswarm` | helmclient/ensure_tiller_installed.go:44 | controller=app-operator | event=update | loop=52077 | version=186624200
```

app-operator tried to check if tiller is installed but it gets stuck for 20 mins. :( This uses context.WithTimeout to ensure we only wait for 10 seconds.

 






