### PR TITLE
helm3: Implement RunReleaseTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,11 @@ jobs:
       E2E_TEST_DIR: "integration/test/basic"
     <<: *e2eTest
 
+  e2eTestReleaseTesting:
+    environment:
+      E2E_TEST_DIR: "integration/test/releasetesting"
+    <<: *e2eTest
+
 # Disable integration tests. They will be re-enabled as Helm 3 logic is added.
 #
 #  e2eTestInstallRelease:
@@ -113,6 +118,9 @@ workflows:
     jobs:
       - build
       - e2eTestBasic:
+          requires:
+          - build
+      - e2eTestReleaseTesting:
           requires:
           - build
 

--- a/helmclient.go
+++ b/helmclient.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/kubeconfig"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/kube"
@@ -83,29 +82,6 @@ func New(config Config) (*Client, error) {
 	}
 
 	return c, nil
-}
-
-// RunReleaseTest runs the tests for a Helm Release. The releaseName is the
-// name of the Helm Release that is set when the Helm Chart is installed. This
-// is the same action as running the helm test command.
-func (c *Client) RunReleaseTest(ctx context.Context, releaseName string, options ReleaseTestOptions) error {
-	eventName := "run_release_test"
-
-	t := prometheus.NewTimer(histogram.WithLabelValues(eventName))
-	defer t.ObserveDuration()
-
-	err := c.runReleaseTest(ctx, releaseName, options)
-	if err != nil {
-		errorGauge.WithLabelValues(eventName).Inc()
-		return microerror.Mask(err)
-	}
-
-	return nil
-}
-
-func (c *Client) runReleaseTest(ctx context.Context, releaseName string, options ReleaseTestOptions) error {
-	c.logger.LogCtx(ctx, "level", "debug", "message", "run release test not yet implemented for helm 3")
-	return nil
 }
 
 // debugLogFunc allows us to pass micrologger to components that expect a

--- a/helmclienttest/helmclient.go
+++ b/helmclienttest/helmclient.go
@@ -88,7 +88,7 @@ func (c *Client) PullChartTarball(ctx context.Context, tarballURL string) (strin
 	return c.pullChartTarballPath, nil
 }
 
-func (c *Client) RunReleaseTest(ctx context.Context, releaseName string, options helmclient.ReleaseTestOptions) error {
+func (c *Client) RunReleaseTest(ctx context.Context, namespace, releaseName string) error {
 	return nil
 }
 

--- a/integration/test/releasetesting/fixtures/failing-test-chart/Chart.yaml
+++ b/integration/test/releasetesting/fixtures/failing-test-chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: failing-test-chart
+version: 3.2.1

--- a/integration/test/releasetesting/fixtures/failing-test-chart/templates/pod.yaml
+++ b/integration/test/releasetesting/fixtures/failing-test-chart/templates/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.pod.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.pod.name }}
+    name: {{ .Values.pod.name }}
+spec:
+  containers:
+  - name: {{ .Values.pod.name }}
+    image: {{ .Values.pod.image.repository }}
+    ports:
+    - name: http
+      containerPort: 80

--- a/integration/test/releasetesting/fixtures/failing-test-chart/templates/service.yaml
+++ b/integration/test/releasetesting/fixtures/failing-test-chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.service.name }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: {{ .Values.pod.name }}

--- a/integration/test/releasetesting/fixtures/failing-test-chart/templates/testing/test-runner.yaml
+++ b/integration/test/releasetesting/fixtures/failing-test-chart/templates/testing/test-runner.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.pod.name }}-test
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  initContainers:
+  # Bash automated testing system
+  # https://github.com/bats-core/bats-core
+  - name: test-framework
+    image: quay.io/giantswarm/bats:0.4.0
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # copy bats to tools dir
+      cp -R /usr/local/libexec/ /tools/bats/
+    volumeMounts:
+    - mountPath: /tools
+      name: tools
+  containers:
+  - name: {{ .Values.pod.name }}-test
+    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    imagePullPolicy: IfNotPresent
+    command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+    volumeMounts:
+    - mountPath: /tests
+      name: tests
+      readOnly: true
+    - mountPath: /tools
+      name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ .Values.pod.name }}-tests
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/integration/test/releasetesting/fixtures/failing-test-chart/templates/testing/tests.yaml
+++ b/integration/test/releasetesting/fixtures/failing-test-chart/templates/testing/tests.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.pod.name }}-tests
+  namespace: {{ .Values.namespace }}
+data:
+  run.sh: |-
+    @test "Testing nginx is reachable" {
+      response=$(curl -I {{ .Values.service.name }}.{{ .Values.namespace }} 2> /dev/null | head -n 1 | cut -d$' ' -f2)
+      [ "$response" -eq 404 ]
+    }

--- a/integration/test/releasetesting/fixtures/failing-test-chart/values.yaml
+++ b/integration/test/releasetesting/fixtures/failing-test-chart/values.yaml
@@ -1,0 +1,19 @@
+# Default values for ingress-controller migration chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+namespace: default
+
+pod:
+  name: nginx
+  image:
+    repository: nginx
+
+service:
+  name: nginx
+
+test:
+  image:
+    registry: quay.io
+    repository: giantswarm/alpine-testing
+    tag: 0.1.0

--- a/integration/test/releasetesting/fixtures/passing-test-chart/Chart.yaml
+++ b/integration/test/releasetesting/fixtures/passing-test-chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for Kubernetes
+name: passing-test-chart
+version: 3.2.1

--- a/integration/test/releasetesting/fixtures/passing-test-chart/templates/pod.yaml
+++ b/integration/test/releasetesting/fixtures/passing-test-chart/templates/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.pod.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.pod.name }}
+    name: {{ .Values.pod.name }}
+spec:
+  containers:
+  - name: {{ .Values.pod.name }}
+    image: {{ .Values.pod.image.repository }}
+    ports:
+    - name: http
+      containerPort: 80

--- a/integration/test/releasetesting/fixtures/passing-test-chart/templates/service.yaml
+++ b/integration/test/releasetesting/fixtures/passing-test-chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.service.name }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: {{ .Values.pod.name }}

--- a/integration/test/releasetesting/fixtures/passing-test-chart/templates/testing/test-runner.yaml
+++ b/integration/test/releasetesting/fixtures/passing-test-chart/templates/testing/test-runner.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.pod.name }}-test
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  initContainers:
+  # Bash automated testing system
+  # https://github.com/bats-core/bats-core
+  - name: test-framework
+    image: quay.io/giantswarm/bats:0.4.0
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # copy bats to tools dir
+      cp -R /usr/local/libexec/ /tools/bats/
+    volumeMounts:
+    - mountPath: /tools
+      name: tools
+  containers:
+  - name: {{ .Values.pod.name }}-test
+    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    imagePullPolicy: IfNotPresent
+    command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+    volumeMounts:
+    - mountPath: /tests
+      name: tests
+      readOnly: true
+    - mountPath: /tools
+      name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ .Values.pod.name }}-tests
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/integration/test/releasetesting/fixtures/passing-test-chart/templates/testing/tests.yaml
+++ b/integration/test/releasetesting/fixtures/passing-test-chart/templates/testing/tests.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.pod.name }}-tests
+  namespace: {{ .Values.namespace }}
+data:
+  run.sh: |-
+    @test "Testing nginx is reachable" {
+      response=$(curl -I {{ .Values.service.name }}.{{ .Values.namespace }} 2> /dev/null | head -n 1 | cut -d$' ' -f2)
+      [ "$response" -eq 200 ]
+    }

--- a/integration/test/releasetesting/fixtures/passing-test-chart/values.yaml
+++ b/integration/test/releasetesting/fixtures/passing-test-chart/values.yaml
@@ -1,0 +1,19 @@
+# Default values for ingress-controller migration chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+namespace: default
+
+pod:
+  name: nginx
+  image:
+    repository: nginx
+
+service:
+  name: nginx
+
+test:
+  image:
+    registry: quay.io
+    repository: giantswarm/alpine-testing
+    tag: 0.1.0

--- a/integration/test/releasetesting/main_test.go
+++ b/integration/test/releasetesting/main_test.go
@@ -1,0 +1,31 @@
+// +build k8srequired
+
+package releasetesting
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/helmclient/integration/setup"
+)
+
+var (
+	config setup.Config
+)
+
+func init() {
+	var err error
+
+	{
+		config, err = setup.NewConfig()
+		if err != nil {
+			panic(fmt.Sprintf("%#v", err))
+		}
+	}
+}
+
+// TestMain allows us to have common setup and teardown steps that are run
+// once for all the tests https://golang.org/pkg/testing/#hdr-Main.
+func TestMain(m *testing.M) {
+	setup.Setup(m, config)
+}

--- a/integration/test/releasetesting/release_testing_test.go
+++ b/integration/test/releasetesting/release_testing_test.go
@@ -1,0 +1,106 @@
+// +build k8srequired
+
+package releasetesting
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/helmclient/integration/charttarball"
+	"github.com/giantswarm/microerror"
+)
+
+func TestBasic(t *testing.T) {
+	ctx := context.Background()
+
+	var failingReleaseName string = "failing-test-chart"
+
+	{
+		err := runReleaseTest(ctx, failingReleaseName)
+		if !helmclient.IsTestReleaseFailure(err) {
+			t.Fatalf("expected release test failure got %#v", err)
+		}
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", failingReleaseName))
+
+		err := config.HelmClient.DeleteRelease(ctx, metav1.NamespaceDefault, failingReleaseName)
+		if err != nil {
+			t.Fatalf("expected nil error got %#v", err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", failingReleaseName))
+	}
+
+	var passingReleaseName string = "passing-test-chart"
+
+	{
+		err := runReleaseTest(ctx, passingReleaseName)
+		if err != nil {
+			t.Fatalf("expected nil error got %#v", err)
+		}
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", passingReleaseName))
+
+		err := config.HelmClient.DeleteRelease(ctx, metav1.NamespaceDefault, passingReleaseName)
+		if err != nil {
+			t.Fatalf("expected nil error got %#v", err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", passingReleaseName))
+	}
+}
+
+func runReleaseTest(ctx context.Context, releaseName string) error {
+	var err error
+	var chartPath = ""
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating tarball for %#q", releaseName))
+
+		chartPath, err = charttarball.Create(releaseName)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		defer os.Remove(chartPath)
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created tarball for %#q", releaseName))
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing %#q", releaseName))
+
+		installOptions := helmclient.InstallOptions{
+			ReleaseName: releaseName,
+			Wait:        true,
+		}
+		err = config.HelmClient.InstallReleaseFromTarball(ctx, chartPath, metav1.NamespaceDefault, map[string]interface{}{}, installOptions)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed %#q", releaseName))
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("running release tests for %#q", releaseName))
+
+		err = config.HelmClient.RunReleaseTest(ctx, metav1.NamespaceDefault, releaseName)
+		if err != nil {
+			config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release test failed for %#q", releaseName))
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release test passed for %#q", releaseName))
+	}
+
+	return nil
+}

--- a/release_testing.go
+++ b/release_testing.go
@@ -1,0 +1,47 @@
+package helmclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/prometheus/client_golang/prometheus"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+// RunReleaseTest runs the tests for a Helm Release. The releaseName is the
+// name of the Helm Release that is set when the Helm Chart is installed. This
+// is the same action as running the helm test command.
+func (c *Client) RunReleaseTest(ctx context.Context, namespace, releaseName string) error {
+	eventName := "run_release_test"
+
+	t := prometheus.NewTimer(histogram.WithLabelValues(eventName))
+	defer t.ObserveDuration()
+
+	err := c.runReleaseTest(ctx, namespace, releaseName)
+	if err != nil {
+		errorGauge.WithLabelValues(eventName).Inc()
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (c *Client) runReleaseTest(ctx context.Context, namespace, releaseName string) error {
+	cfg, err := c.newActionConfig(ctx, namespace)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	releaseTesting := action.NewReleaseTesting(cfg)
+	releaseTesting.Namespace = namespace
+
+	res, err := releaseTesting.Run(releaseName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("RELEASE %#v", res))
+
+	return nil
+}

--- a/spec.go
+++ b/spec.go
@@ -42,7 +42,7 @@ type Interface interface {
 	PullChartTarball(ctx context.Context, tarballURL string) (string, error)
 	// RunReleaseTest runs the tests for a Helm Release. This is the same
 	// action as running the helm test command.
-	RunReleaseTest(ctx context.Context, releaseName string, options ReleaseTestOptions) error
+	RunReleaseTest(ctx context.Context, namespace, releaseName string) error
 	// UpdateReleaseFromTarball updates the given release using the chart packaged
 	// in the tarball.
 	UpdateReleaseFromTarball(ctx context.Context, chartPath, namespace, releaseName string, values map[string]interface{}, options UpdateOptions) error
@@ -65,12 +65,6 @@ type InstallOptions struct {
 	Namespace   string
 	ReleaseName string
 	Wait        bool
-}
-
-// ReleaseTestOptions is the subset of supported options when running helm
-// release tests.
-type ReleaseTestOptions struct {
-	Namespace string
 }
 
 // UpdateOptions is the subset of supported options when updating helm releases.


### PR DESCRIPTION
Towards giantswarm/roadmap#30

Implements final method for running helm release tests. Adds a new integration test with passing and failing helm tests.