### PR TITLE
Retry if pulling chart tarball fails

### DIFF
--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -63,8 +63,6 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 		resp, err := c.httpClient.Do(req)
 		if isNoSuchHostError(err) {
 			return backoff.Permanent(microerror.Maskf(pullChartFailedError, "no such host %#q", req.Host))
-		} else if IsPullChartTimeout(err) {
-			return backoff.Permanent(microerror.Maskf(pullChartTimeoutError, "%#q timeout for %#q", req.Method, req.URL.String()))
 		} else if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9079

Currently we return a permanent error if we hit a timout. So we don't use the retry logic.

This is dumb since the retry might succeed. We still cancel the resource in chart-operator if there is a timeout after the retries.