### PR TITLE
Pin dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -255,41 +255,41 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e9e6c4c2ae7f624a6eb1b768c582c05f200041de51faf5151b8e074eae917b57"
+  digest = "1:2673e930820371280627226d65918e45097a145a656fc1d7a92505f26610d3cf"
   name = "github.com/giantswarm/errors"
   packages = ["tenant"]
   pruneopts = "UT"
-  revision = "2640113be13f2eec85fe785ed74418a1a2852e5d"
+  revision = "924f9ee3873810de9f288da9bbab5246de195f41"
 
 [[projects]]
   branch = "master"
-  digest = "1:a6fdcbdc9a98d2174017f2a00e32e835c3ee6739e15a476285e981ab6d7e4627"
+  digest = "1:640d18361eaa8641ce7d857b613a4e946b30c3d9f50d07adda07390d72e98122"
   name = "github.com/giantswarm/k8sclient"
   packages = [
     ".",
     "k8scrdclient",
   ]
   pruneopts = "UT"
-  revision = "78de8231ec254eba941e9999c2b13581b2d2103b"
+  revision = "f888a8ac48619e166eb78bd93fc7eb8a5a544cd4"
 
 [[projects]]
   branch = "master"
-  digest = "1:42649fa57594fd0dd202a5cf01d9cae946ff99e0e8f87bc9c145860a2e57c17a"
+  digest = "1:7b4402ea4cd2c0a5c1c0a7eb60a84fe06ee5c077adfeac9b4b1f2544c683f607"
   name = "github.com/giantswarm/k8sportforward"
   packages = ["."]
   pruneopts = "UT"
-  revision = "676e7106283c008acc4c07c0cfc903c18cdbeda3"
+  revision = "1c93e34022a6ac23a8763221340f5bb25fae32a8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d80347cb345b2986422040821735ae0efba8b8093b765b146b90796d926b85b4"
+  digest = "1:701a5f5a7297ced0c7b9aeeba6a40ef47663b956d56e7acd09fe0d1c31eb1e4b"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
+  digest = "1:4e616fe01d486048e77342e2c5e638f8744ec6da802335633740aafb057f50d8"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -297,8 +297,8 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
-  version = "v0.1.0"
+  revision = "c4d217562e3d493e3ff571707346a5a2653475cb"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,11 +60,11 @@ required = [
 
 [[constraint]]
   name = "github.com/giantswarm/microerror"
-  branch = "master"
+  version = "~0.1.0"
 
 [[constraint]]
   name = "github.com/giantswarm/micrologger"
-  version = "v0.1.0"
+  version = "~0.1.0"
 
 [[constraint]]
   name = "github.com/google/go-cmp"

--- a/vendor/github.com/giantswarm/errors/tenant/error.go
+++ b/vendor/github.com/giantswarm/errors/tenant/error.go
@@ -16,12 +16,18 @@ var (
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
 		// A regular expression representing EOF errors for the tenant API domain.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
+		// A regular expression representing EOF errors for the tenant API domain.
+		// These may occur when initializing controller runtime clients.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api\?timeout.*: (EOF|context deadline exceeded)`),
 		// A regular expression representing TLS errors related to establishing
 		// connections to tenant clusters while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
 		// A regular expression representing timeout errors related to establishing
 		// TCP connections to tenant clusters while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp .* i/o timeout`),
+		// A regular expression representing timeout errors related to awaiting headers
+		// from the tenant API connection.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..* .* \(Client.Timeout exceeded while awaiting headers\)`),
 		// A regular expression representing the kind of transient errors related to
 		// certificates returned while the tenant API is not fully up.
 		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate has expired or is not yet valid.*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),

--- a/vendor/github.com/giantswarm/k8sclient/Gopkg.lock
+++ b/vendor/github.com/giantswarm/k8sclient/Gopkg.lock
@@ -63,23 +63,23 @@
   revision = "4dd4911251929a0ac4c4f3d8c4bda482a9e09f30"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d80347cb345b2986422040821735ae0efba8b8093b765b146b90796d926b85b4"
+  digest = "1:701a5f5a7297ced0c7b9aeeba6a40ef47663b956d56e7acd09fe0d1c31eb1e4b"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:2275349e37657984a6cfc425803962b3f46843532b37b7a4552c5356086dffc6"
+  digest = "1:20fe82d087077d505e906c36177da3edb09897430812a437adb1dac497dc4371"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
     "loggermeta",
   ]
   pruneopts = "UT"
-  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
-  version = "v0.1.0"
+  revision = "c4d217562e3d493e3ff571707346a5a2653475cb"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/vendor/github.com/giantswarm/k8sclient/Gopkg.toml
+++ b/vendor/github.com/giantswarm/k8sclient/Gopkg.toml
@@ -36,11 +36,11 @@
 
 [[constraint]]
   name = "github.com/giantswarm/microerror"
-  branch = "master"
+  version = "~0.1.0"
 
 [[constraint]]
   name = "github.com/giantswarm/micrologger"
-  version = "v0.1.0"
+  version = "~0.1.0"
 
 [[constraint]]
   name = "k8s.io/api"

--- a/vendor/github.com/giantswarm/k8sportforward/Gopkg.lock
+++ b/vendor/github.com/giantswarm/k8sportforward/Gopkg.lock
@@ -29,12 +29,12 @@
   revision = "d73c753520d9250e8f091d70d468a99c71f8bceb"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d80347cb345b2986422040821735ae0efba8b8093b765b146b90796d926b85b4"
+  digest = "1:701a5f5a7297ced0c7b9aeeba6a40ef47663b956d56e7acd09fe0d1c31eb1e4b"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:582e25eccee928dc12416ea4c23b6dae8f3b5687730632aa1473ebebe80a2359"
@@ -101,7 +101,7 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "ac88ee75c92c889b97e05591e9a39b6480c538b3"
+  revision = "e9b2fee46413994441b28dfca259d911d963dfed"
 
 [[projects]]
   branch = "master"
@@ -116,29 +116,29 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "ef20fe5d793301b553005db740f730d87993f778"
+  revision = "c0dbc17a35534bf2e581d7a942408dc936316da4"
 
 [[projects]]
   branch = "master"
-  digest = "1:8d1c112fb1679fa097e9a9255a786ee47383fa2549a3da71bcb1334a693ebcfe"
+  digest = "1:55d36eb35766a3f105fa36cfb2faf053cc33c019108a6adee799c4e7d59d62b2"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "5d9234df094ce600ff541158d1491aa10d078a47"
+  revision = "858c2ad4c8b6c5d10852cb89079f6ca1c7309787"
 
 [[projects]]
   branch = "master"
-  digest = "1:055d921edfad0ae56ef0d21a124a002cf3a669b4c42e85b810abf0225226e2a3"
+  digest = "1:8191c209ac2aaba9e958a061256fab8955ad10cc731aa609660184800f1ef55a"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "63cb32ae39b28d6bb8e7e215c1fc39dd80dcdb02"
+  revision = "eeba5f6aabab6d6594a9191d6bfeaca5fa6a8248"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"

--- a/vendor/github.com/giantswarm/k8sportforward/Gopkg.toml
+++ b/vendor/github.com/giantswarm/k8sportforward/Gopkg.toml
@@ -27,7 +27,7 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/microerror/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/microerror/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] 2020-02-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/microerror/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/microerror/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] 2020-03-04
+
+### Changed
+
+- Updated microerror to `v0.1.0.
+
 ## [0.1.0] 2020-02-13
 
 ### Added
@@ -12,4 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release.
 
 [Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.1]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.1
 [0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.lock
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:9c432418e5180be62a4bf565761eb2c618fc4ff9b7efa9a260c92068f453e28a"
+  digest = "1:98e9dc8d46288ca1cbcd2925710b5fc684514ddba062e109f35a40ad5e81de8f"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = ""
-  revision = "a8d5d4f526c526b4b773062958847fe7e0b7f449"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.toml
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]


### PR DESCRIPTION
We need to pin the microerror and micrologger dependencies to the v0.1.0 version to avoid getting breaking changes.