### PR TITLE
Handle missing tarballs when updating releases

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -617,6 +617,8 @@ func (c *Client) updateReleaseFromTarball(ctx context.Context, releaseName, path
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
+		} else if IsTarballNotFound(err) {
+			return backoff.Permanent(microerror.Mask(err))
 		} else if IsYamlConversionFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9246

We check `IsTarballNotFound` on install but not on update. We should check in both cases. As there is no point retrying if the tarball does not exist.