### PR TITLE
helm3:  Add constants for statuses

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -35,6 +35,17 @@ const (
 	StatusPendingRollback = "pending-rollback"
 )
 
+var (
+	// ReleaseTransitionStatuses is used to determine if the Helm Release is
+	// currently being updated.
+	ReleaseTransitionStatuses = map[string]bool{
+		StatusUninstalled:     true,
+		StatusPendingInstall:  true,
+		StatusPendingUpgrade:  true,
+		StatusPendingRollback: true,
+	}
+)
+
 const (
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.

--- a/spec.go
+++ b/spec.go
@@ -56,7 +56,7 @@ const (
 	runReleaseTestTimout = 300
 )
 
-// Interface describes the methods provided by the helm client.
+// Interface describes the methods provided by the Helm client.
 type Interface interface {
 	// DeleteRelease uninstalls a chart given its release name.
 	DeleteRelease(ctx context.Context, namespace, releaseName string) error
@@ -85,6 +85,8 @@ type Interface interface {
 	UpdateReleaseFromTarball(ctx context.Context, chartPath, namespace, releaseName string, values map[string]interface{}, options UpdateOptions) error
 }
 
+// RESTClientGetter is used to configure the action package which is the Helm
+// Go client.
 type RESTClientGetter interface {
 	// ToDiscoveryClient returns discovery client
 	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
@@ -96,7 +98,7 @@ type RESTClientGetter interface {
 	ToRESTMapper() (meta.RESTMapper, error)
 }
 
-// InstallOptions is the subset of supported options when installing helm
+// InstallOptions is the subset of supported options when installing Helm
 // releases.
 type InstallOptions struct {
 	Namespace   string
@@ -104,7 +106,7 @@ type InstallOptions struct {
 	Wait        bool
 }
 
-// UpdateOptions is the subset of supported options when updating helm releases.
+// UpdateOptions is the subset of supported options when updating Helm releases.
 type UpdateOptions struct {
 	Force bool
 	Wait  bool

--- a/spec.go
+++ b/spec.go
@@ -25,10 +25,6 @@ const (
 	StatusSuperseded = "superseded"
 	// StatusFailed indicates that the release was not successfully deployed.
 	StatusFailed = "failed"
-	// StatusNotInstalled indicates that an error occurred and Helm could not
-	// create a release. NOTE: This status is Giant Swarm specific and DOES
-	// NOT map to a Helm status.
-	StatusNotInstalled = "not installed"
 	// StatusUninstalling indicates that a uninstall operation is underway.
 	StatusUninstalling = "uninstalling"
 	// StatusPendingInstall indicates that an install operation is underway.

--- a/spec.go
+++ b/spec.go
@@ -25,6 +25,10 @@ const (
 	StatusSuperseded = "superseded"
 	// StatusFailed indicates that the release was not successfully deployed.
 	StatusFailed = "failed"
+	// StatusNotInstalled indicates that an error occurred and Helm could not
+	// create a release. NOTE: This status is Giant Swarm specific and DOES
+	// NOT map to a Helm status.
+	StatusNotInstalled = "not installed"
 	// StatusUninstalling indicates that a uninstall operation is underway.
 	StatusUninstalling = "uninstalling"
 	// StatusPendingInstall indicates that an install operation is underway.

--- a/spec.go
+++ b/spec.go
@@ -9,6 +9,32 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Describes the status of a release. This needs to be kept in sync with
+// upstream but it allows us to have constants without importing Helm
+// packages.
+//
+// See: https://github.com/helm/helm/blob/master/pkg/release/status.go
+const (
+	// StatusUnknown indicates that a release is in an uncertain state.
+	StatusUnknown = "unknown"
+	// StatusDeployed indicates that the release has been pushed to Kubernetes.
+	StatusDeployed = "deployed"
+	// StatusUninstalled indicates that a release has been uninstalled from Kubernetes.
+	StatusUninstalled = "uninstalled"
+	// StatusSuperseded indicates that this release object is outdated and a newer one exists.
+	StatusSuperseded = "superseded"
+	// StatusFailed indicates that the release was not successfully deployed.
+	StatusFailed = "failed"
+	// StatusUninstalling indicates that a uninstall operation is underway.
+	StatusUninstalling = "uninstalling"
+	// StatusPendingInstall indicates that an install operation is underway.
+	StatusPendingInstall = "pending-install"
+	// StatusPendingUpgrade indicates that an upgrade operation is underway.
+	StatusPendingUpgrade = "pending-upgrade"
+	// StatusPendingRollback indicates that an rollback operation is underway.
+	StatusPendingRollback = "pending-rollback"
+)
+
 const (
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.


### PR DESCRIPTION
Towards giantswarm/roadmap#30

The Helm release statuses change with Helm 3. In chart-operator the strings are hardcoded in lots of places.

This adds them as constants here. The rationale is so we can have constants but without importing helm packages.