### PR TITLE
Handle 503 errors when pulling chart tarballs fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Handle 503 errors when pulling chart tarballs fails.
+
 ## [0.2.0] 2020-03-25
 
 ### Changed

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -80,6 +80,11 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 				return backoff.Permanent(microerror.Maskf(pullChartNotFoundError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
 			}
 
+			// Github Pages 503 produces full HTML page which obscures the logs.
+			if resp.StatusCode == http.StatusServiceUnavailable {
+				return backoff.Permanent(microerror.Maskf(pullChartFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
+			}
+
 			return microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q with body %s", resp.StatusCode, req.URL.String(), buf.String()))
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9946

We should handle 503 errors from GitHub Pages. chart-operator will then cancel the release resource and retry correctly.

## Checklist

- [x] Update changelog in CHANGELOG.md.
