### PR TITLE
Increase HTTP client timeout from 5 to 30 secs for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Handle 503 errors when pulling chart tarballs fails.
+- Make HTTP client timeout for pulling chart tarballs configurable.
 
 ## [0.2.0] 2020-03-25
 

--- a/helmclient.go
+++ b/helmclient.go
@@ -54,6 +54,7 @@ type Config struct {
 	Logger     micrologger.Logger
 
 	EnsureTillerInstalledMaxWait time.Duration
+	HTTPClientTimeout            time.Duration
 	RestConfig                   *rest.Config
 	TillerImageName              string
 	TillerImageRegistry          string
@@ -91,6 +92,9 @@ func New(config Config) (*Client, error) {
 	if config.EnsureTillerInstalledMaxWait == 0 {
 		config.EnsureTillerInstalledMaxWait = defaultEnsureTillerInstalledMaxWait
 	}
+	if config.HTTPClientTimeout == 0 {
+		config.HTTPClientTimeout = defaultHTTPClientTimeout
+	}
 	if config.RestConfig == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.RestConfig must not be empty", config)
 	}
@@ -106,7 +110,7 @@ func New(config Config) (*Client, error) {
 
 	// Set client timeout to prevent leakages.
 	httpClient := &http.Client{
-		Timeout: time.Second * httpClientTimeout,
+		Timeout: time.Second * time.Duration(config.HTTPClientTimeout),
 	}
 
 	// Registry is configurable for AWS China.

--- a/spec.go
+++ b/spec.go
@@ -16,7 +16,7 @@ const (
 	// release by default.
 	defaultMaxHistory = 10
 	// httpClientTimeout is the timeout when pulling tarballs.
-	httpClientTimeout = 5
+	httpClientTimeout = 30
 	// runReleaseTestTimeout is the timeout in seconds when running tests.
 	runReleaseTestTimout = 300
 

--- a/spec.go
+++ b/spec.go
@@ -15,8 +15,8 @@ const (
 	// defaultMaxHistory is the maximum number of release versions stored per
 	// release by default.
 	defaultMaxHistory = 10
-	// httpClientTimeout is the timeout when pulling tarballs.
-	httpClientTimeout = 30
+	// defaultHTTPClientTimeout is the timeout when pulling tarballs.
+	defaultHTTPClientTimeout = 5 * time.Second
 	// runReleaseTestTimeout is the timeout in seconds when running tests.
 	runReleaseTestTimout = 300
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9946

We currently use a hardcoded HTTP client timeout of 5 secs when pulling chart tarballs. This is regularly timing out in AWS China due to the slow network. 

This makes it configurable so it can be increased in these installations.

## Checklist

- [x] Update changelog in CHANGELOG.md.
