### PR TITLE
Helm3 error handling

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -76,7 +76,7 @@ func New(config Config) (*Client, error) {
 
 	// Set client timeout to prevent leakages.
 	httpClient := &http.Client{
-		Timeout: config.HTTPClientTimeout,
+		Timeout: time.Second * time.Duration(config.HTTPClientTimeout),
 	}
 
 	c := &Client{

--- a/helmclient.go
+++ b/helmclient.go
@@ -34,6 +34,8 @@ type Config struct {
 	HelmClient Interface
 	K8sClient  k8sclient.Interface
 	Logger     micrologger.Logger
+
+	HTTPClientTimeout time.Duration
 }
 
 // Client knows how to talk with Helm.
@@ -68,9 +70,13 @@ func New(config Config) (*Client, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
 
+	if config.HTTPClientTimeout == 0 {
+		config.HTTPClientTimeout = defaultHTTPClientTimeout
+	}
+
 	// Set client timeout to prevent leakages.
 	httpClient := &http.Client{
-		Timeout: time.Second * httpClientTimeout,
+		Timeout: config.HTTPClientTimeout,
 	}
 
 	c := &Client{

--- a/pull_chart_tarball.go
+++ b/pull_chart_tarball.go
@@ -82,6 +82,11 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 				return backoff.Permanent(microerror.Maskf(pullChartNotFoundError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
 			}
 
+			// Github Pages 503 produces full HTML page which obscures the logs.
+			if resp.StatusCode == http.StatusServiceUnavailable {
+				return backoff.Permanent(microerror.Maskf(pullChartFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
+			}
+
 			return microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q with body %s", resp.StatusCode, req.URL.String(), buf.String()))
 		}
 

--- a/spec.go
+++ b/spec.go
@@ -47,8 +47,8 @@ var (
 )
 
 const (
-	// httpClientTimeout is the timeout when pulling tarballs.
-	httpClientTimeout = 5
+	// defaultHTTPClientTimeout is the timeout when pulling tarballs.
+	defaultHTTPClientTimeout = 5
 )
 
 // Interface describes the methods provided by the Helm client.


### PR DESCRIPTION
Syncing helm3 branch with master.

- Handle 503s when GitHub Pages is unavailable https://github.com/giantswarm/helmclient/pull/196
- Make HTTP client timeout configurable so it can be increased in AWS China. https://github.com/giantswarm/helmclient/pull/198

