### PR TITLE
Add manifest error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added manifest validation error.
+
 ## [1.0.0] 2020-05-18
 
 ### Changed

--- a/error.go
+++ b/error.go
@@ -106,6 +106,32 @@ func IsInvalidGZipHeader(err error) bool {
 	return false
 }
 
+const (
+	invalidManifestPrefix = "unable to build kubernetes objects from release manifest"
+)
+
+var invalidManifestError = &microerror.Error{
+	Kind: "invalidManifestError",
+}
+
+// IsInvalidManifest asserts invalidManifestError.
+func IsInvalidManifest(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasPrefix(c.Error(), invalidManifestPrefix) {
+		return true
+	}
+	if c == invalidManifestError {
+		return true
+	}
+
+	return false
+}
+
 var notFoundError = &microerror.Error{
 	Kind: "notFoundError",
 }


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11167

To support the below error message from helm 3, we are adding a new error matcher function. 
```
unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in PodSecurityPolicy.metadata.labels.app

```
## Checklist

- [x] Update changelog in CHANGELOG.md.
