### PR TITLE
Add validationFailedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added new validation error for both upgrade/install cases.
+
 ## [1.0.1] 2020-05-26
 
 ### Added

--- a/error.go
+++ b/error.go
@@ -361,3 +361,29 @@ func IsYamlConversionFailed(err error) bool {
 
 	return false
 }
+
+var (
+	validationFailedErrorText = "error validating data"
+)
+
+var validationFailedError = &microerror.Error{
+	Kind: "validationFailedError",
+}
+
+// IsValidationFailedError asserts validationFailedError.
+func IsValidationFailedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == validationFailedError {
+		return true
+	}
+	if strings.Contains(c.Error(), validationFailedErrorText) {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11260

To my surprise, `helm install` & `helm upgrade` have a different logging message when same validation has a problem. 

this PR introduces `validationFailedError` which checks the same words for both validation error cases. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
