### PR TITLE
Extending map merging errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add new yaml parsing errors.
+
 ## [1.0.2] 2020-05-29
 
 - Add new validation error for both install and upgrade cases.

--- a/error.go
+++ b/error.go
@@ -141,6 +141,24 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
+var parsingDestFailedError = &microerror.Error{
+	Kind: "parsingDestFailedError",
+}
+
+// IsParsingDestFailedError asserts parsingDestFailedError.
+func IsParsingDestFailedError(err error) bool {
+	return microerror.Cause(err) == parsingDestFailedError
+}
+
+var parsingSrcFailedError = &microerror.Error{
+	Kind: "parsingSrcFailedError",
+}
+
+// IsparsingSrcFailedError asserts parsingSrcFailedError.
+func IsParsingSrcFailedError(err error) bool {
+	return microerror.Cause(err) == parsingSrcFailedError
+}
+
 var pullChartFailedError = &microerror.Error{
 	Kind: "pullChartFailedError",
 }

--- a/merge_values.go
+++ b/merge_values.go
@@ -24,12 +24,12 @@ func MergeValues(destMap, srcMap map[string][]byte) (map[string]interface{}, err
 
 	destVals, err := processYAML(destMap)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return nil, microerror.Maskf(parsingDestFailedError, err.Error())
 	}
 
 	srcVals, err := processYAML(srcMap)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return nil, microerror.Maskf(parsingSrcFailedError, err.Error())
 	}
 
 	result = mergeValues(destVals, srcVals)

--- a/merge_values_test.go
+++ b/merge_values_test.go
@@ -62,6 +62,12 @@ nested: null`
 const nullValuedYaml = `
 null`
 
+const wrongYaml = `
+nested:
+    values: "nested"
+    - data: 
+"`
+
 func Test_MergeValues(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -142,7 +148,7 @@ func Test_MergeValues(t *testing.T) {
 				"another": []byte("test: val"),
 				"test":    []byte("test: val"),
 			},
-			errorMatcher: IsExecutionFailed,
+			errorMatcher: IsParsingSrcFailedError,
 		},
 		{
 			name: "case 6: dest map with multiple keys returns error",
@@ -153,7 +159,7 @@ func Test_MergeValues(t *testing.T) {
 			srcMap: map[string][]byte{
 				"test": []byte("test: val"),
 			},
-			errorMatcher: IsExecutionFailed,
+			errorMatcher: IsParsingDestFailedError,
 		},
 		{
 			name: "case 7: null-valued key in src overrides/removes intersecting tree in dest",
@@ -177,6 +183,16 @@ func Test_MergeValues(t *testing.T) {
 				"override": []byte(nullValuedYaml),
 			},
 			expectedValues: map[string]interface{}{},
+		},
+		{
+			name: "case 10: wrong dest yaml returns error",
+			destMap: map[string][]byte{
+				"test": []byte(wrongYaml),
+			},
+			srcMap: map[string][]byte{
+				"test": []byte("test: val"),
+			},
+			errorMatcher: IsParsingDestFailedError,
 		},
 	}
 


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11469

I will use new errors in chart-operator, to let users know they have a problem in their configmap/secret.

## Checklist

- [x] Update changelog in CHANGELOG.md.
