### PR TITLE
Exposing Release namespace 

### DIFF
--- a/helmclient.go
+++ b/helmclient.go
@@ -323,6 +323,7 @@ func (c *Client) getReleaseHistory(ctx context.Context, releaseName string) (*Re
 			Description:  release.Info.Description,
 			LastDeployed: lastDeployed,
 			Name:         release.Name,
+			Namespace:    release.Namespace,
 			Revision:     int(release.Version),
 			Version:      version,
 		}
@@ -865,9 +866,10 @@ func releaseToReleaseContent(release *hapirelease.Release) (*ReleaseContent, err
 	}
 
 	content := &ReleaseContent{
-		Name:   release.Name,
-		Status: release.Info.Status.Code.String(),
-		Values: values.AsMap(),
+		Name:      release.Name,
+		Namespace: release.Namespace,
+		Status:    release.Info.Status.Code.String(),
+		Values:    values.AsMap(),
 	}
 
 	return content, nil

--- a/helmclient_test.go
+++ b/helmclient_test.go
@@ -95,8 +95,9 @@ func Test_GetReleaseContent(t *testing.T) {
 				}),
 			},
 			expectedContent: &ReleaseContent{
-				Name:   "chart-operator",
-				Status: "DEPLOYED",
+				Name:      "chart-operator",
+				Namespace: "default",
+				Status:    "DEPLOYED",
 				Values: map[string]interface{}{
 					// Note: Values cannot be configured via the Helm mock client.
 					"name": "value",
@@ -115,8 +116,9 @@ func Test_GetReleaseContent(t *testing.T) {
 				}),
 			},
 			expectedContent: &ReleaseContent{
-				Name:   "chart-operator",
-				Status: "FAILED",
+				Name:      "chart-operator",
+				Namespace: "default",
+				Status:    "FAILED",
 				Values: map[string]interface{}{
 					"name": "value",
 				},
@@ -194,6 +196,7 @@ func Test_GetReleaseHistory(t *testing.T) {
 				AppVersion:  "1.0.0",
 				Description: "Release mock",
 				Name:        "chart-operator",
+				Namespace:   "default",
 				// LastDeployed is hardcoded in the fake Helm Client.
 				LastDeployed: time.Unix(242085845, 0).UTC(),
 				Revision:     1,
@@ -221,6 +224,7 @@ func Test_GetReleaseHistory(t *testing.T) {
 				AppVersion:  "2.0.0",
 				Description: "Release mock",
 				Name:        "chart-operator",
+				Namespace:   "default",
 				// LastDeployed is hardcoded in the fake Helm Client.
 				LastDeployed: time.Unix(242085845, 0).UTC(),
 				Revision:     1,
@@ -371,8 +375,9 @@ func Test_Client_ListReleaseContents(t *testing.T) {
 			},
 			expectedContents: []*ReleaseContent{
 				{
-					Name:   "foobar",
-					Status: "DEPLOYED",
+					Name:      "foobar",
+					Namespace: "default",
+					Status:    "DEPLOYED",
 					Values: map[string]interface{}{
 						"name": "value",
 					},
@@ -394,15 +399,17 @@ func Test_Client_ListReleaseContents(t *testing.T) {
 			},
 			expectedContents: []*ReleaseContent{
 				{
-					Name:   "foobar",
-					Status: "DEPLOYED",
+					Name:      "foobar",
+					Namespace: "default",
+					Status:    "DEPLOYED",
 					Values: map[string]interface{}{
 						"name": "value",
 					},
 				},
 				{
-					Name:   "jabberwocky",
-					Status: "DEPLOYED",
+					Name:      "jabberwocky",
+					Namespace: "not-default",
+					Status:    "DEPLOYED",
 					Values: map[string]interface{}{
 						"name": "value",
 					},
@@ -426,15 +433,17 @@ func Test_Client_ListReleaseContents(t *testing.T) {
 			},
 			expectedContents: []*ReleaseContent{
 				{
-					Name:   "foobar",
-					Status: "DEPLOYED",
+					Name:      "foobar",
+					Namespace: "default",
+					Status:    "DEPLOYED",
 					Values: map[string]interface{}{
 						"name": "value",
 					},
 				},
 				{
-					Name:   "jabberwocky",
-					Status: "FAILED",
+					Name:      "jabberwocky",
+					Namespace: "default",
+					Status:    "FAILED",
 					Values: map[string]interface{}{
 						"name": "value",
 					},
@@ -460,8 +469,9 @@ func Test_Client_ListReleaseContents(t *testing.T) {
 			},
 			expectedContents: []*ReleaseContent{
 				{
-					Name:   "foobar",
-					Status: "DEPLOYED",
+					Name:      "foobar",
+					Namespace: "default",
+					Status:    "DEPLOYED",
 					Values: map[string]interface{}{
 						"name": "value",
 					},

--- a/types.go
+++ b/types.go
@@ -12,6 +12,8 @@ type Chart struct {
 type ReleaseContent struct {
 	// Name is the name of the Helm Release.
 	Name string
+	// Namespace is the namespace of the Helm Release.
+	Namespace string
 	// Status is the Helm status code of the Release.
 	Status string
 	// Values are the values provided when installing the Helm Release.
@@ -28,6 +30,8 @@ type ReleaseHistory struct {
 	LastDeployed time.Time
 	// Name is the name of the Helm Release.
 	Name string
+	// Namespace is the namespace of the Helm Release.
+	Namespace string
 	// Revision is the revision number of the Helm Release.
 	Revision int
 	// Version is the version of the Helm Chart that has been deployed.


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11651

There's no way to extract release namespace information from any other resources. 
Hence I'm back to change the spec of helmclient for 0.x.x.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
