### PR TITLE
Add rollback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add rollback support.
+
 ## [1.0.5] - 2020-07-17
 
 ### Added

--- a/helmclienttest/helmclient.go
+++ b/helmclienttest/helmclient.go
@@ -88,6 +88,10 @@ func (c *Client) PullChartTarball(ctx context.Context, tarballURL string) (strin
 	return c.pullChartTarballPath, nil
 }
 
+func (c *Client) Rollback(ctx context.Context, namespace, releaseName string, revision int, options helmclient.RollbackOptions) error {
+	return nil
+}
+
 func (c *Client) RunReleaseTest(ctx context.Context, namespace, releaseName string) error {
 	return nil
 }

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -68,6 +68,10 @@ func TestBasic(t *testing.T) {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("loaded chart tarball %#q", chartPath))
 	}
 
+	values := map[string]interface{}{
+		"my": "value",
+	}
+
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing %#q", releaseName))
 
@@ -75,7 +79,7 @@ func TestBasic(t *testing.T) {
 			ReleaseName: releaseName,
 			Wait:        true,
 		}
-		err = config.HelmClient.InstallReleaseFromTarball(ctx, chartPath, metav1.NamespaceDefault, map[string]interface{}{}, installOptions)
+		err = config.HelmClient.InstallReleaseFromTarball(ctx, chartPath, metav1.NamespaceDefault, values, installOptions)
 		if err != nil {
 			t.Fatalf("could not install chart %v", err)
 		}
@@ -111,6 +115,7 @@ func TestBasic(t *testing.T) {
 			Name:        releaseName,
 			Revision:    1,
 			Status:      helmclient.StatusDeployed,
+			Values:      values,
 			Version:     "0.1.1",
 		}
 
@@ -154,8 +159,9 @@ func TestBasic(t *testing.T) {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("got release history for %#q", releaseName))
 	}
 
-	values := map[string]interface{}{
+	updatedValues := map[string]interface{}{
 		"another": "value",
+		"my":      "value",
 	}
 
 	{
@@ -164,7 +170,7 @@ func TestBasic(t *testing.T) {
 		updateOptions := helmclient.UpdateOptions{
 			Wait: true,
 		}
-		err = config.HelmClient.UpdateReleaseFromTarball(ctx, chartPath, metav1.NamespaceDefault, releaseName, values, updateOptions)
+		err = config.HelmClient.UpdateReleaseFromTarball(ctx, chartPath, metav1.NamespaceDefault, releaseName, updatedValues, updateOptions)
 		if err != nil {
 			t.Fatalf("could not update chart %v", err)
 		}
@@ -186,10 +192,8 @@ func TestBasic(t *testing.T) {
 			Name:        releaseName,
 			Revision:    2,
 			Status:      helmclient.StatusDeployed,
-			Values: map[string]interface{}{
-				"another": "value",
-			},
-			Version: "0.1.1",
+			Values:      updatedValues,
+			Version:     "0.1.1",
 		}
 
 		if releaseContent.LastDeployed.IsZero() {
@@ -230,10 +234,11 @@ func TestBasic(t *testing.T) {
 
 		expectedContent := &helmclient.ReleaseContent{
 			AppVersion:  "v1.8.0",
-			Description: "Install complete",
+			Description: "Rollback to 1",
 			Name:        releaseName,
-			Revision:    1,
+			Revision:    3,
 			Status:      helmclient.StatusDeployed,
+			Values:      values,
 			Version:     "0.1.1",
 		}
 

--- a/rollback.go
+++ b/rollback.go
@@ -1,0 +1,56 @@
+package helmclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/giantswarm/microerror"
+	"github.com/prometheus/client_golang/prometheus"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+// Rollback executes a rollback to a previous revision of a Helm release.
+func (c *Client) Rollback(ctx context.Context, namespace, releaseName string, revision int, options RollbackOptions) error {
+	eventName := "rollback"
+
+	t := prometheus.NewTimer(histogram.WithLabelValues(eventName))
+	defer t.ObserveDuration()
+
+	err := c.rollback(ctx, namespace, releaseName, revision, options)
+	if err != nil {
+		errorGauge.WithLabelValues(eventName).Inc()
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (c *Client) rollback(ctx context.Context, namespace, releaseName string, revision int, options RollbackOptions) error {
+	cfg, err := c.newActionConfig(ctx, namespace)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	rollback := action.NewRollback(cfg)
+
+	// Configure action with supported rollback options.
+	options.configure(rollback, namespace, revision)
+
+	err = rollback.Run(releaseName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (options RollbackOptions) configure(action *action.Rollback, namespace string, revision int) {
+	if options.Timeout == 0 {
+		options.Timeout = time.Second * defaultK8sClientTimeout
+	}
+
+	action.Force = options.Force
+	action.Timeout = options.Timeout
+	action.Version = revision
+	action.Wait = options.Wait
+}

--- a/spec.go
+++ b/spec.go
@@ -77,6 +77,8 @@ type Interface interface {
 	// PullChartTarball downloads a tarball from the provided tarball URL,
 	// returning the file path.
 	PullChartTarball(ctx context.Context, tarballURL string) (string, error)
+	// Rollback executes a rollback to a previous revision of a Helm release.
+	Rollback(ctx context.Context, namespace, releaseName string, revision int, options RollbackOptions) error
 	// RunReleaseTest runs the tests for a Helm Release. This is the same
 	// action as running the helm test command.
 	RunReleaseTest(ctx context.Context, namespace, releaseName string) error
@@ -105,6 +107,14 @@ type InstallOptions struct {
 	ReleaseName string
 	Timeout     time.Duration
 	Wait        bool
+}
+
+// RollbackOptions is the subset of supported options when rollback back Helm releases.
+type RollbackOptions struct {
+	Force   bool
+	Timeout time.Duration
+	Version int
+	Wait    bool
 }
 
 // UpdateOptions is the subset of supported options when updating Helm releases.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12245

Currently `helm upgrade --force` is unusable for us as it doesn't recreate resources it just disables the 3 way merge. Without recreate support Helm errors when updating immutable fields.

So this is prep for implementing automated rollback support in chart-operator.

## Checklist

- [x] Update changelog in CHANGELOG.md.
