### PR TITLE
Revalidate the cached request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Validate the cache to prevent pulling stale cache objects ([giantswarm/giantswarm/9747](https://github.com/giantswarm/giantswarm/issues/9747))
+
 ## [3.0.0] - 2020-10-27
 
 ### Changed

--- a/pkg/helmclient/pull_chart_tarball.go
+++ b/pkg/helmclient/pull_chart_tarball.go
@@ -126,6 +126,7 @@ func (c *Client) newRequest(method, url string) (*http.Request, error) {
 	}
 
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Cache-Control", "no-cache")
 
 	return req, nil
 }


### PR DESCRIPTION
If a request is made and 404 is initially returned, make sure that subsequent
requests revalidate the cached entry (preventing 404 when asset exists)

fix giantswam/giantswarm#9747

## Checklist

- [x] Update changelog in CHANGELOG.md.
